### PR TITLE
fix(git): handle binary files in staged diff without crashing

### DIFF
--- a/noidea/git.py
+++ b/noidea/git.py
@@ -1,6 +1,7 @@
 """Git subprocess wrappers that return structured dataclasses instead of raw output."""
 
 import os
+import re
 import subprocess
 from dataclasses import dataclass
 
@@ -64,20 +65,54 @@ def get_staged_files() -> list[str]:
     return [f for f in result.stdout.strip().splitlines() if f]
 
 
+def _strip_binary_hunks(diff_text: str) -> str:
+    """Remove binary file hunks from a unified diff, keeping a summary line.
+
+    Binary hunks bloat the prompt without adding useful context for commit
+    message generation.  We keep the diff header so the AI knows *which*
+    binary files changed.
+    """
+    assert isinstance(diff_text, str), "diff_text must be a string"
+
+    # Split on "diff --git" boundaries, keeping the delimiter.
+    parts = re.split(r"(?=^diff --git )", diff_text, flags=re.MULTILINE)
+
+    cleaned: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        # Git marks binary content with this sentinel line.
+        if "Binary files" in part or "GIT binary patch" in part:
+            # Keep only the header line so the AI sees the filename.
+            header = part.split("\n", 1)[0]
+            cleaned.append(header + "\n[binary file — diff omitted]\n")
+        else:
+            cleaned.append(part)
+
+    result = "".join(cleaned)
+    assert isinstance(result, str), "result must be a string"
+    return result
+
+
 def get_diff() -> DiffResult:
     try:
-        # check=True: staged diff is required for the core feature, so failure is an error.
+        # text=False: binary diffs contain non-UTF-8 bytes that crash text mode.
         result = subprocess.run(
-            ["git", "diff", "--staged"], capture_output=True, text=True, check=True
+            ["git", "diff", "--staged"], capture_output=True, check=True
         )
 
         if not result.stdout:
             return DiffResult(has_changes=False)
-        else:
-            return DiffResult(has_changes=True, diff=result.stdout)
+
+        # Decode with replace to survive any stray non-UTF-8 bytes.
+        diff_text = result.stdout.decode("utf-8", errors="replace")
+        diff_text = _strip_binary_hunks(diff_text)
+
+        assert isinstance(diff_text, str), "diff must be a string after processing"
+        return DiffResult(has_changes=True, diff=diff_text)
 
     except subprocess.CalledProcessError as e:
-        return DiffResult(has_changes=False, error=e.stderr)
+        return DiffResult(has_changes=False, error=e.stderr.decode("utf-8", errors="replace"))
 
     except FileNotFoundError as e:
         return DiffResult(has_changes=False, error=str(e))

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,12 +1,13 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from noidea.git import get_diff, get_hooks_dir, install_hook
+from noidea.git import _strip_binary_hunks, get_diff, get_hooks_dir, install_hook
 
 
 def test_get_diff_nothing_staged():
     mock_result = MagicMock()
-    mock_result.stdout = ""
+    # subprocess.run runs without text=True, so stdout is bytes.
+    mock_result.stdout = b""
 
     with patch("noidea.git.subprocess.run", return_value=mock_result):
         result = get_diff()
@@ -16,7 +17,7 @@ def test_get_diff_nothing_staged():
 
 def test_get_diff_with_staged_changes():
     mock_result = MagicMock()
-    mock_result.stdout = "deff --git a/foo.py b/foo.py\n+some change"
+    mock_result.stdout = b"deff --git a/foo.py b/foo.py\n+some change"
 
     with patch("noidea.git.subprocess.run", return_value=mock_result):
         result = get_diff()
@@ -100,11 +101,56 @@ def test_get_diff_git_not_found():
 def test_get_diff_git_command_fails():
     import subprocess
 
-    error = subprocess.CalledProcessError(128, "git", stderr="fatal: not a git repo")
+    error = subprocess.CalledProcessError(128, "git", stderr=b"fatal: not a git repo")
     with patch("noidea.git.subprocess.run", side_effect=error):
         result = get_diff()
     assert not result.has_changes
     assert result.error == "fatal: not a git repo"
+
+
+def test_strip_binary_hunks_omits_binary_payload():
+    diff = (
+        "diff --git a/logo.png b/logo.png\n"
+        "new file mode 100644\n"
+        "index 0000000..abc1234\n"
+        "Binary files /dev/null and b/logo.png differ\n"
+    )
+    cleaned = _strip_binary_hunks(diff)
+    assert "diff --git a/logo.png b/logo.png" in cleaned
+    assert "[binary file — diff omitted]" in cleaned
+    assert "Binary files" not in cleaned
+
+
+def test_strip_binary_hunks_keeps_text_diffs():
+    diff = "diff --git a/foo.py b/foo.py\n@@ -1 +1 @@\n-old\n+new\n"
+    cleaned = _strip_binary_hunks(diff)
+    assert cleaned == diff
+
+
+def test_strip_binary_hunks_mixed_keeps_text_strips_binary():
+    diff = (
+        "diff --git a/foo.py b/foo.py\n@@ -1 +1 @@\n-old\n+new\n"
+        "diff --git a/logo.png b/logo.png\n"
+        "Binary files a/logo.png and b/logo.png differ\n"
+    )
+    cleaned = _strip_binary_hunks(diff)
+    assert "+new" in cleaned
+    assert "[binary file — diff omitted]" in cleaned
+    assert "Binary files" not in cleaned
+
+
+def test_get_diff_strips_binary_and_survives_bad_bytes():
+    mock_result = MagicMock()
+    # Invalid UTF-8 byte (0xff) plus a binary hunk: must not crash.
+    mock_result.stdout = (
+        b"diff --git a/logo.png b/logo.png\n"
+        b"Binary files a/logo.png and b/logo.png differ\xff\n"
+    )
+    with patch("noidea.git.subprocess.run", return_value=mock_result):
+        result = get_diff()
+    assert result.has_changes
+    assert "[binary file — diff omitted]" in result.diff
+    assert "Binary files" not in result.diff
 
 
 def test_install_hook_not_in_repo():


### PR DESCRIPTION
## Summary

`get_diff()` ran `git diff --staged` with `text=True`, which decodes stdout as UTF-8. A staged diff containing **binary files** (images, compiled artifacts) emits non-UTF-8 bytes and raised `UnicodeDecodeError`, killing commit-message generation entirely.

This PR:
- Reads the diff as **raw bytes** and decodes with `errors="replace"`, so stray bytes can never crash us.
- Adds `_strip_binary_hunks()` to drop binary payloads while keeping each file's header — the AI still sees *which* binary files changed without the prompt being bloated by unusable binary content.
- Applies the same byte-decoding fix to the `stderr` error path.

## Testing

- Updated the existing `get_diff` tests to mock **bytes** (matching real `subprocess` output without `text=True`) — the previous mocks were asserting a `str` interface that no longer holds.
- Added coverage for the new behavior: binary stripping, text-diff passthrough, mixed diffs, and an end-to-end invalid-UTF-8 (`\xff`) case.
- Full suite: **76 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Binary file payloads are now stripped from diffs while preserving file headers for cleaner output.
  * Improved robustness when handling git command failures and invalid UTF-8 encoding in diff content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AccursedGalaxy/noidea/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->