### PR TITLE
docs(changelog): note binary-diff fix in v1.0.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.1] - 2026-05-21
 
+### Fixed
+- Handle binary file diffs correctly: read `git diff` as bytes and strip binary hunks so non-UTF-8 content no longer crashes commit message generation (keeps a summary line so the AI still sees which binary files changed)
+
 ### Changed
-- Bump dependencies for security and maintenance, with no source or behavior changes:
+- Bump dependencies for security and maintenance:
   - `anthropic` 0.86.0 → 0.103.1
   - `cryptography` 46.0.6 → 48.0.0
   - `idna` 3.11 → 3.15


### PR DESCRIPTION
The binary file diff fix (#13) merged into `main` alongside the dependency bumps, so it ships as part of **v1.0.1**. This corrects the v1.0.1 changelog entry to record it under `### Fixed` and removes the now-inaccurate "no source or behavior changes" wording.

Docs-only change. After merge, `main` will be tagged `v1.0.1` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)