### PR TITLE
refactor: give the API key store a single owner (key_store module)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Introduce a `key_store` module that owns both API-key stores (the OS keyring secret and the `keys.json` registry) behind one interface (`add`/`remove`/`list`/`get`/`status_of`). `add` and `remove` now write both stores together and roll back on partial failure, so a failed operation leaves no half-written state. `provider.py`, `commands/keys.py`, and `commands/status.py` call this interface and no longer import `keyring` directly; the key-registry functions move out of `config.py`. Tests back the keyring with an in-memory fake instead of mocking the OS keyring.
+
 ## [1.0.1] - 2026-05-21
 
 ### Fixed

--- a/noidea/commands/keys.py
+++ b/noidea/commands/keys.py
@@ -1,10 +1,7 @@
-import json
-
-import keyring
-import keyring.errors
 import typer
 
-from noidea.config import SERVICE_NAME, Provider, list_keys, remove_key, save_key
+from noidea.config import Provider
+from noidea.key_store import KeyStoreError, key_store
 
 keys_app = typer.Typer(help="Manage your API keys. The one secret you actually need to keep.")
 
@@ -13,12 +10,12 @@ keys_app = typer.Typer(help="Manage your API keys. The one secret you actually n
 def show():
     """Show your saved API keys."""
     try:
-        keys = list_keys()
+        keys = key_store.list()
         if not keys:
             print("No keys found. Run 'noidea keys add' to get started.")
         for key in keys:
             print(key)
-    except (OSError, json.JSONDecodeError) as e:
+    except KeyStoreError as e:
         print(f"Couldn't read keys: {e}")
 
 
@@ -27,14 +24,11 @@ def add(provider: Provider = typer.Argument(default=Provider.ANTHROPIC)):
     """Stash an API key in your keyring."""
     try:
         key = typer.prompt("Enter your key:", hide_input=True)
-        keyring.set_password(service_name=SERVICE_NAME, username=provider.value, password=key)
-        if save_key(provider.value):
+        if key_store.add(provider.value, key):
             print("Key saved. You're ready to have no idea what to commit.")
         else:
             print("You already have a key saved for this provider.")
-    except keyring.errors.KeyringError as e:
-        print(f"Couldn't save the key to keyring: {e}")
-    except (OSError, json.JSONDecodeError) as e:
+    except KeyStoreError as e:
         print(f"Couldn't save the key: {e}")
 
 
@@ -42,12 +36,9 @@ def add(provider: Provider = typer.Argument(default=Provider.ANTHROPIC)):
 def remove(provider: Provider = typer.Argument(...)):
     """Remove an API key from your keyring."""
     try:
-        keyring.delete_password(service_name=SERVICE_NAME, username=provider.value)
-        if remove_key(provider.value):
+        if key_store.remove(provider.value):
             print("Key removed. Gone, like your commit message inspiration.")
         else:
             print("Key not found. Nothing to remove.")
-    except keyring.errors.KeyringError as e:
-        print(f"Couldn't remove the key from keyring: {e}")
-    except (OSError, json.JSONDecodeError) as e:
+    except KeyStoreError as e:
         print(f"Couldn't remove the key: {e}")

--- a/noidea/commands/status.py
+++ b/noidea/commands/status.py
@@ -1,13 +1,11 @@
-import json
 import os
 
-import keyring
-import keyring.errors
 from rich.console import Console
 
 from noidea import __version__
-from noidea.config import CONFIG_PATH, SERVICE_NAME, list_keys, load_config
+from noidea.config import CONFIG_PATH, SERVICE_NAME, load_config
 from noidea.git import HOOK_NAME, get_git_root, get_hooks_dir
+from noidea.key_store import KeyStatus, KeyStoreError, key_store
 
 console = Console(stderr=True)
 
@@ -62,19 +60,16 @@ def _check_config() -> tuple[dict, dict]:
 
 def _check_api_keys():
     try:
-        keys = list_keys()
-        if keys:
-            for key in keys:
-                stored = keyring.get_password(SERVICE_NAME, key)
-                if stored:
-                    console.print(f"API Key:        {OK} {key} (keyring)")
-                else:
-                    console.print(
-                        f"API Key:        {FAIL} {key} registered but missing from keyring"
-                    )
-        else:
+        keys = key_store.list()
+        if not keys:
             console.print(f"API Key:        {FAIL} no key found (run 'noidea keys add')")
-    except (OSError, json.JSONDecodeError, keyring.errors.KeyringError):
+            return
+        for key in keys:
+            if key_store.status_of(key) is KeyStatus.PRESENT:
+                console.print(f"API Key:        {OK} {key} (keyring)")
+            else:
+                console.print(f"API Key:        {FAIL} {key} registered but missing from keyring")
+    except KeyStoreError:
         console.print(f"API Key:        {FAIL} could not read keys")
 
 

--- a/noidea/config.py
+++ b/noidea/config.py
@@ -10,11 +10,9 @@ from noidea.git import get_git_root
 SERVICE_NAME = "noidea"
 CONFIG_DIR_NAME = ".noidea"
 CONFIG_FILENAME = "config.json"
-KEYS_FILENAME = "keys.json"
 
 CONFIG_DIR = os.path.expanduser(f"~/{CONFIG_DIR_NAME}")
 CONFIG_PATH = os.path.join(CONFIG_DIR, CONFIG_FILENAME)
-KEYS_PATH = os.path.join(CONFIG_DIR, KEYS_FILENAME)
 
 DEFAULTS = {
     "llm": {
@@ -132,36 +130,4 @@ def initialize():
         except OSError as error:
             print(f"Warning: could not write {CONFIG_PATH}: {error}", file=sys.stderr)
 
-    if not os.path.exists(KEYS_PATH):
-        try:
-            with open(KEYS_PATH, "w") as f:
-                json.dump([], f)
-        except OSError as error:
-            print(f"Warning: could not write {KEYS_PATH}: {error}", file=sys.stderr)
-
-
-def save_key(name: str):
-    with open(KEYS_PATH) as f:
-        keys = json.load(f)
-    if name in keys:
-        return False
-    keys.append(name)
-    with open(KEYS_PATH, "w") as f:
-        json.dump(keys, f)
-    return True
-
-
-def remove_key(name: str):
-    with open(KEYS_PATH) as f:
-        keys = json.load(f)
-    if name not in keys:
-        return False
-    keys.remove(name)
-    with open(KEYS_PATH, "w") as f:
-        json.dump(keys, f)
-    return True
-
-
-def list_keys() -> list:
-    with open(KEYS_PATH) as f:
-        return json.load(f)
+    # The API-key registry is owned by key_store, which creates keys.json lazily on first add.

--- a/noidea/key_store.py
+++ b/noidea/key_store.py
@@ -1,0 +1,156 @@
+"""Single owner of the API-key invariant: a keyring secret is bound to a name in keys.json.
+
+Two stores exist because the OS keyring offers no "list usernames" API, so a JSON registry
+enumerates the provider names. This module owns the coordination between them — every registered
+name has a keyring secret and vice-versa — so callers never touch keyring or the registry directly.
+"""
+
+import json
+import os
+from enum import Enum
+
+import keyring
+from dotenv import load_dotenv
+
+from noidea.config import CONFIG_DIR, SERVICE_NAME
+
+# Load .env here because this module owns the env-var fallback for the secret.
+load_dotenv()
+
+KEYS_FILENAME = "keys.json"
+KEYS_PATH = os.path.join(CONFIG_DIR, KEYS_FILENAME)
+
+ANTHROPIC_ENV_VAR = "ANTHROPIC_API_KEY"
+
+
+class KeyStoreError(Exception):
+    """A keyring or registry operation failed. Callers handle this one type, not keyring's."""
+
+
+class KeyStatus(Enum):
+    """The reconciliation state of a provider across the two stores."""
+
+    PRESENT = "present"  # Registered and the keyring holds its secret.
+    MISSING_SECRET = "missing_secret"  # Registered but the keyring has no secret (drift).
+    UNREGISTERED = "unregistered"  # Not in the registry at all.
+
+
+class KeyStore:
+    """Owns the keyring secret store and the JSON name registry behind one interface."""
+
+    def __init__(self, keyring_backend, registry_path: str):
+        assert keyring_backend is not None, "keyring_backend must be provided"
+        assert isinstance(registry_path, str) and registry_path, "registry_path must be non-empty"
+        self._keyring = keyring_backend
+        self._registry_path = registry_path
+
+    def add(self, provider: str, secret: str) -> bool:
+        """Write the secret to the keyring and register the name; True if newly registered.
+
+        Reads the registry first so a corrupt registry fails before any store is touched.
+        If the registry write fails after the keyring write, the keyring secret is rolled
+        back so no orphan secret survives the failure.
+        """
+        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        assert isinstance(secret, str) and secret, "secret must be a non-empty string"
+        names = self._read_registry()
+        try:
+            self._keyring.set_password(SERVICE_NAME, provider, secret)
+        except keyring.errors.KeyringError as error:
+            raise KeyStoreError(f"could not write secret to keyring: {error}") from error
+        if provider in names:
+            return False
+        names.append(provider)
+        try:
+            self._write_registry(names)
+        except KeyStoreError:
+            self._delete_quietly(provider)
+            raise
+        return True
+
+    def remove(self, provider: str) -> bool:
+        """Remove the name from the registry and the secret from the keyring; True if it existed."""
+        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        names = self._read_registry()
+        if provider not in names:
+            return False
+        names.remove(provider)
+        self._write_registry(names)
+        try:
+            self._keyring.delete_password(SERVICE_NAME, provider)
+        except keyring.errors.PasswordDeleteError:
+            # The secret was already absent (prior drift); the goal state is reached anyway.
+            pass
+        except keyring.errors.KeyringError as error:
+            # Roll back the registry so the two stores never disagree after a failure.
+            names.append(provider)
+            self._write_registry(names)
+            raise KeyStoreError(f"could not delete secret from keyring: {error}") from error
+        return True
+
+    def list(self) -> list[str]:
+        """Return the registered provider names."""
+        names = self._read_registry()
+        assert isinstance(names, list), "registry must be a list"
+        return names
+
+    def get(self, provider: str) -> str | None:
+        """Return the secret from the keyring, falling back to the env var for Anthropic."""
+        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        secret = self._read_secret(provider)
+        if not secret and provider == "anthropic":
+            secret = os.environ.get(ANTHROPIC_ENV_VAR)
+        assert secret is None or isinstance(secret, str), "secret must be a string or None"
+        return secret
+
+    def status_of(self, provider: str) -> KeyStatus:
+        """Reconcile the two stores for one provider into a single status."""
+        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        registered = provider in self._read_registry()
+        # Read the keyring directly, bypassing the env fallback, so real drift stays visible.
+        has_secret = bool(self._read_secret(provider))
+        if not registered:
+            return KeyStatus.UNREGISTERED
+        return KeyStatus.PRESENT if has_secret else KeyStatus.MISSING_SECRET
+
+    def _read_secret(self, provider: str) -> str | None:
+        """Read the raw keyring secret, surfacing backend failures as KeyStoreError."""
+        try:
+            return self._keyring.get_password(SERVICE_NAME, provider)
+        except keyring.errors.KeyringError as error:
+            raise KeyStoreError(f"could not read secret from keyring: {error}") from error
+
+    def _delete_quietly(self, provider: str) -> None:
+        """Best-effort keyring delete used to roll back a half-written add; never raises."""
+        try:
+            self._keyring.delete_password(SERVICE_NAME, provider)
+        except keyring.errors.KeyringError:
+            # Rollback is best-effort: the original failure is what the caller must see.
+            pass
+
+    def _read_registry(self) -> list[str]:
+        """Read the registry, treating a missing file as an empty registry."""
+        if not os.path.exists(self._registry_path):
+            return []
+        try:
+            with open(self._registry_path) as f:
+                names = json.load(f)
+        except (OSError, json.JSONDecodeError) as error:
+            raise KeyStoreError(
+                f"could not read registry {self._registry_path}: {error}"
+            ) from error
+        assert isinstance(names, list), "registry must deserialize to a list"
+        return names
+
+    def _write_registry(self, names: list[str]) -> None:
+        assert isinstance(names, list), "names must be a list"
+        try:
+            with open(self._registry_path, "w") as f:
+                json.dump(names, f)
+        except OSError as error:
+            raise KeyStoreError(
+                f"could not write registry {self._registry_path}: {error}"
+            ) from error
+
+
+key_store = KeyStore(keyring, KEYS_PATH)

--- a/noidea/key_store.py
+++ b/noidea/key_store.py
@@ -5,6 +5,10 @@ enumerates the provider names. This module owns the coordination between them â€
 name has a keyring secret and vice-versa â€” so callers never touch keyring or the registry directly.
 """
 
+# Defer annotation evaluation: the `list` method below shadows the builtin `list`, which would
+# otherwise break `-> list[str]` annotations at class-definition time on Python < 3.14.
+from __future__ import annotations
+
 import json
 import os
 from enum import Enum

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -1,25 +1,18 @@
 """Thin Anthropic API wrapper: key retrieval and commit message generation."""
 
-import os
-
-import keyring
 from anthropic import Anthropic
 from anthropic.types import TextBlock
-from dotenv import load_dotenv
 
-from noidea.config import SERVICE_NAME, Provider
-
-load_dotenv()
+from noidea.config import Provider
+from noidea.key_store import key_store
 
 
 def get_api_key(provider: Provider = Provider.ANTHROPIC) -> str:
-    # Keyring first: credentials stay out of the process environment.
-    key = keyring.get_password(service_name=SERVICE_NAME, username=provider.value)
-    if not key:
-        # Fall back to env var for CI and headless environments.
-        key = os.environ.get("ANTHROPIC_API_KEY")
+    # key_store consults the keyring first, then the ANTHROPIC_API_KEY env var for CI/headless.
+    key = key_store.get(provider.value)
     if not key:
         raise SystemExit("No API key found. Run 'noidea keys add'.")
+    assert isinstance(key, str) and key, "api key must be a non-empty string"
     return key
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,36 @@
+"""Test doubles for the key_store seam: an in-memory keyring with no OS dependency."""
+
+import keyring.errors
+
+
+class InMemoryKeyring:
+    """Mimics the keyring module interface, backed by a dict instead of the OS keyring.
+
+    Keyed by (service_name, username) so it behaves like the real namespaced store.
+    Optional failure injection lets tests exercise the half-written-state rollback paths.
+    """
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+        self.set_should_fail = False
+        self.delete_should_fail = False
+
+    def get_password(self, service_name: str, username: str) -> str | None:
+        assert isinstance(service_name, str), "service_name must be a string"
+        assert isinstance(username, str), "username must be a string"
+        return self._store.get((service_name, username))
+
+    def set_password(self, service_name: str, username: str, password: str) -> None:
+        assert isinstance(username, str), "username must be a string"
+        assert isinstance(password, str), "password must be a string"
+        if self.set_should_fail:
+            raise keyring.errors.KeyringError("injected set failure")
+        self._store[(service_name, username)] = password
+
+    def delete_password(self, service_name: str, username: str) -> None:
+        assert isinstance(username, str), "username must be a string"
+        if self.delete_should_fail:
+            raise keyring.errors.KeyringError("injected delete failure")
+        if (service_name, username) not in self._store:
+            raise keyring.errors.PasswordDeleteError("no such password")
+        del self._store[(service_name, username)]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from noidea.cli import app
 from noidea.git import DiffResult, HookResult
+from noidea.key_store import KeyStoreError
 
 runner = CliRunner()
 
@@ -220,67 +221,58 @@ class TestSuggestErrors:
 
 
 class TestKeysErrors:
-    """Error paths in keys commands."""
+    """Error paths in keys commands surface as a single KeyStoreError."""
 
     def test_show_keys_file_error(self):
-        with patch("noidea.commands.keys.list_keys", side_effect=OSError("read error")):
+        with patch("noidea.commands.keys.key_store.list", side_effect=KeyStoreError("read error")):
             result = runner.invoke(app, ["keys", "show"])
         assert "Couldn't read keys" in result.output
 
     def test_add_key_keyring_error(self):
-        import keyring.errors
-
-        with (
-            patch(
-                "noidea.commands.keys.keyring.set_password",
-                side_effect=keyring.errors.KeyringError("locked"),
-            ),
-        ):
+        with patch("noidea.commands.keys.key_store.add", side_effect=KeyStoreError("locked")):
             result = runner.invoke(app, ["keys", "add"], input="secret\n")
         assert "Couldn't save the key" in result.output
 
     def test_remove_key_keyring_error(self):
-        import keyring.errors
-
-        with (
-            patch(
-                "noidea.commands.keys.keyring.delete_password",
-                side_effect=keyring.errors.KeyringError("locked"),
-            ),
-        ):
+        with patch("noidea.commands.keys.key_store.remove", side_effect=KeyStoreError("locked")):
             result = runner.invoke(app, ["keys", "remove", "anthropic"])
         assert "Couldn't remove the key" in result.output
 
 
 class TestKeysAdd:
-    @patch("noidea.commands.keys.save_key")
-    @patch("noidea.commands.keys.keyring")
-    def test_add_key(self, mock_keyring, mock_save):
+    @patch("noidea.commands.keys.key_store.add", return_value=True)
+    def test_add_key(self, mock_add):
         result = runner.invoke(app, ["keys", "add"], input="secret-key\n")
         assert result.exit_code == 0
         assert "Key saved" in result.output
-        mock_keyring.set_password.assert_called_once_with(
-            service_name="noidea", username="anthropic", password="secret-key"
-        )
-        mock_save.assert_called_once_with("anthropic")
+        mock_add.assert_called_once_with("anthropic", "secret-key")
+
+    @patch("noidea.commands.keys.key_store.add", return_value=False)
+    def test_add_key_already_exists(self, mock_add):
+        result = runner.invoke(app, ["keys", "add"], input="secret-key\n")
+        assert result.exit_code == 0
+        assert "already have a key" in result.output
 
 
 class TestKeysRemove:
-    @patch("noidea.commands.keys.remove_key")
-    @patch("noidea.commands.keys.keyring")
-    def test_remove_key(self, mock_keyring, mock_remove):
+    @patch("noidea.commands.keys.key_store.remove", return_value=True)
+    def test_remove_key(self, mock_remove):
         result = runner.invoke(app, ["keys", "remove", "anthropic"])
         assert result.exit_code == 0
         assert "Key removed" in result.output
-        mock_keyring.delete_password.assert_called_once_with(
-            service_name="noidea", username="anthropic"
-        )
         mock_remove.assert_called_once_with("anthropic")
+
+    @patch("noidea.commands.keys.key_store.remove", return_value=False)
+    def test_remove_key_not_found(self, mock_remove):
+        result = runner.invoke(app, ["keys", "remove", "anthropic"])
+        assert result.exit_code == 0
+        assert "Key not found" in result.output
 
 
 class TestKeysList:
-    @patch("noidea.commands.keys.list_keys")
+    @patch("noidea.commands.keys.key_store.list", return_value=["anthropic"])
     def test_list_keys(self, mock_list):
         result = runner.invoke(app, ["keys", "show"])
         assert result.exit_code == 0
+        assert "anthropic" in result.output
         mock_list.assert_called_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,10 +5,7 @@ from noidea.config import (
     DEFAULTS,
     deep_merge,
     initialize,
-    list_keys,
     load_config,
-    remove_key,
-    save_key,
     validate_config,
 )
 
@@ -18,7 +15,6 @@ def _patch_paths(tmp_path):
     return (
         patch("noidea.config.CONFIG_DIR", str(tmp_path)),
         patch("noidea.config.CONFIG_PATH", str(tmp_path / "config.json")),
-        patch("noidea.config.KEYS_PATH", str(tmp_path / "keys.json")),
     )
 
 
@@ -56,8 +52,8 @@ class TestDeepMerge:
 
 
 def test_load_config_returns_defaults_after_initialize(tmp_path):
-    p1, p2, p3 = _patch_paths(tmp_path)
-    with p1, p2, p3, _patch_no_repo():
+    p1, p2 = _patch_paths(tmp_path)
+    with p1, p2, _patch_no_repo():
         initialize()
         result = load_config()
 
@@ -118,8 +114,8 @@ def test_load_config_repo_partial_override(tmp_path):
 
 
 def test_load_config_defaults_have_all_expected_keys(tmp_path):
-    p1, p2, p3 = _patch_paths(tmp_path)
-    with p1, p2, p3, _patch_no_repo():
+    p1, p2 = _patch_paths(tmp_path)
+    with p1, p2, _patch_no_repo():
         initialize()
         result = load_config()
 
@@ -128,65 +124,6 @@ def test_load_config_defaults_have_all_expected_keys(tmp_path):
     assert "context_limit" in result["llm"]
     assert "system_prompt" in result["llm"]
     assert "max_tokens" in result["llm"]
-
-
-class TestSaveKey:
-    def test_save_key_creates_new_file(self, tmp_path):
-        p1, p2, p3 = _patch_paths(tmp_path)
-        with p1, p2, p3:
-            initialize()
-            save_key("Anthropic")
-
-        with open(tmp_path / "keys.json") as f:
-            assert json.load(f) == ["Anthropic"]
-
-    def test_save_key_appends_to_existing(self, tmp_path):
-        keys_file = tmp_path / "keys.json"
-        keys_file.write_text(json.dumps(["Anthropic"]))
-
-        with patch("noidea.config.KEYS_PATH", str(keys_file)):
-            save_key("OpenAI")
-
-        with open(keys_file) as f:
-            assert json.load(f) == ["Anthropic", "OpenAI"]
-
-
-class TestRemoveKey:
-    def test_remove_key_removes_from_list(self, tmp_path):
-        keys_file = tmp_path / "keys.json"
-        keys_file.write_text(json.dumps(["Anthropic", "OpenAI"]))
-
-        with patch("noidea.config.KEYS_PATH", str(keys_file)):
-            remove_key("Anthropic")
-
-        with open(keys_file) as f:
-            assert json.load(f) == ["OpenAI"]
-
-    def test_remove_key_missing_key_does_nothing(self, tmp_path):
-        p1, p2, p3 = _patch_paths(tmp_path)
-        with p1, p2, p3:
-            initialize()
-            result = remove_key("Anthropic")  # key not in list, should not raise
-        assert result is False
-
-
-class TestListKeys:
-    def test_list_keys_prints_keys(self, tmp_path):
-        keys_file = tmp_path / "keys.json"
-        keys_file.write_text(json.dumps(["Anthropic"]))
-
-        with patch("noidea.config.KEYS_PATH", str(keys_file)):
-            result = list_keys()
-
-        assert "Anthropic" in result
-
-    def test_list_keys_empty_after_initialize(self, tmp_path):
-        p1, p2, p3 = _patch_paths(tmp_path)
-        with p1, p2, p3:
-            initialize()
-            result = list_keys()
-
-        assert result == []
 
 
 class TestValidateConfig:
@@ -263,7 +200,6 @@ class TestInitializeErrors:
             patch("noidea.config.CONFIG_DIR", str(tmp_path / "no" / "way")),
             patch("noidea.config.os.makedirs", side_effect=OSError("Permission denied")),
             patch("noidea.config.CONFIG_PATH", str(tmp_path / "config.json")),
-            patch("noidea.config.KEYS_PATH", str(tmp_path / "keys.json")),
         ):
             initialize()
 
@@ -272,8 +208,8 @@ class TestInitializeErrors:
         assert "Permission denied" in captured.err
 
     def test_config_write_failure_prints_warning(self, tmp_path, capsys):
-        p1, p2, p3 = _patch_paths(tmp_path)
-        with p1, p2, p3:
+        p1, p2 = _patch_paths(tmp_path)
+        with p1, p2:
             # Create dir but make config write fail.
             with patch("builtins.open", side_effect=OSError("Disk full")):
                 initialize()

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -1,0 +1,111 @@
+"""Unit tests for the key_store module, exercised through an in-memory keyring fake."""
+
+import pytest
+
+from noidea.config import SERVICE_NAME
+from noidea.key_store import KeyStatus, KeyStore, KeyStoreError
+from tests.fakes import InMemoryKeyring
+
+
+def _make_store(tmp_path):
+    """Build a KeyStore wired to a fake keyring and a temp registry file."""
+    return KeyStore(InMemoryKeyring(), str(tmp_path / "keys.json"))
+
+
+class TestAddAndGet:
+    def test_add_then_get_round_trips_the_secret(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-secret-123")
+        assert store.get("anthropic") == "sk-secret-123"
+
+    def test_add_returns_true_when_newly_registered(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.add("anthropic", "sk-1") is True
+
+    def test_add_returns_false_when_already_registered(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-1")
+        assert store.add("anthropic", "sk-2") is False
+
+    def test_get_returns_none_when_no_secret_and_no_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        store = _make_store(tmp_path)
+        assert store.get("anthropic") is None
+
+    def test_get_falls_back_to_env_var_for_anthropic(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key-456")
+        store = _make_store(tmp_path)
+        assert store.get("anthropic") == "env-key-456"
+
+
+class TestList:
+    def test_list_is_empty_for_fresh_store(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.list() == []
+
+    def test_list_returns_registered_names(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-1")
+        assert store.list() == ["anthropic"]
+
+
+class TestRemove:
+    def test_remove_clears_both_stores(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-1")
+        assert store.remove("anthropic") is True
+        assert store.list() == []
+        assert store.get("anthropic") is None
+
+    def test_remove_returns_false_when_not_registered(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.remove("anthropic") is False
+
+
+class TestStatusOf:
+    def test_present_when_registered_with_secret(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-1")
+        assert store.status_of("anthropic") is KeyStatus.PRESENT
+
+    def test_unregistered_when_never_added(self, tmp_path):
+        store = _make_store(tmp_path)
+        assert store.status_of("anthropic") is KeyStatus.UNREGISTERED
+
+    def test_missing_secret_when_registered_but_keyring_empty(self, tmp_path):
+        store = _make_store(tmp_path)
+        store.add("anthropic", "sk-1")
+        # Simulate drift: the registry keeps the name but the keyring secret vanishes.
+        store._keyring.delete_password(SERVICE_NAME, "anthropic")
+        assert store.status_of("anthropic") is KeyStatus.MISSING_SECRET
+
+
+class TestAtomicity:
+    """A failure on either store leaves no observable half-written state."""
+
+    def test_add_rolls_back_keyring_when_registry_write_fails(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        fake = InMemoryKeyring()
+        # A registry path under a missing directory makes the registry write fail.
+        store = KeyStore(fake, str(tmp_path / "missing" / "keys.json"))
+        with pytest.raises(KeyStoreError):
+            store.add("anthropic", "sk-1")
+        assert fake.get_password(SERVICE_NAME, "anthropic") is None
+
+    def test_add_raises_and_leaves_registry_empty_when_keyring_fails(self, tmp_path):
+        fake = InMemoryKeyring()
+        fake.set_should_fail = True
+        store = KeyStore(fake, str(tmp_path / "keys.json"))
+        with pytest.raises(KeyStoreError):
+            store.add("anthropic", "sk-1")
+        assert store.list() == []
+
+    def test_remove_rolls_back_registry_when_keyring_delete_fails(self, tmp_path):
+        fake = InMemoryKeyring()
+        store = KeyStore(fake, str(tmp_path / "keys.json"))
+        store.add("anthropic", "sk-1")
+        fake.delete_should_fail = True
+        with pytest.raises(KeyStoreError):
+            store.remove("anthropic")
+        assert store.list() == ["anthropic"]

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,24 +6,15 @@ from noidea.provider import get_api_key, get_commit_message
 
 
 class TestGetApiKey:
-    @patch("noidea.provider.keyring")
-    def test_returns_keyring_key_first(self, mock_keyring):
-        mock_keyring.get_password.return_value = "kr-key-123"
+    @patch("noidea.provider.key_store")
+    def test_returns_key_from_store(self, mock_store):
+        mock_store.get.return_value = "kr-key-123"
         assert get_api_key() == "kr-key-123"
-        mock_keyring.get_password.assert_called_once_with(
-            service_name="noidea", username="anthropic"
-        )
+        mock_store.get.assert_called_once_with("anthropic")
 
-    @patch("noidea.provider.keyring")
-    def test_falls_back_to_env_var(self, mock_keyring, monkeypatch):
-        mock_keyring.get_password.return_value = None
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key-456")
-        assert get_api_key() == "env-key-456"
-
-    @patch("noidea.provider.keyring")
-    def test_exits_when_no_key_found(self, mock_keyring, monkeypatch):
-        mock_keyring.get_password.return_value = None
-        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    @patch("noidea.provider.key_store")
+    def test_exits_when_no_key_found(self, mock_store):
+        mock_store.get.return_value = None
         with pytest.raises(SystemExit):
             get_api_key()
 


### PR DESCRIPTION
Closes #18

## Problem

An API key lived in **two stores** — the OS keyring (the secret) and `~/.noidea/keys.json` (a registry of provider names) — with no module owning the invariant binding them: *every name in `keys.json` should have a secret in the keyring, and vice-versa.* Coordination was open-coded in every caller, written non-atomically (a secret could be stored but unregistered, or vice-versa), and a branch of `status` existed only to detect the drift the design permitted.

## Change

Introduce **`noidea/key_store.py`** as the single owner of both stores behind one interface:

- **`add` / `remove`** write the keyring and registry **together** and roll back the side that succeeded if the other fails — so a partial failure leaves no observable half-written state.
- **`get`** preserves the `ANTHROPIC_API_KEY` env-var fallback for CI/headless.
- **`status_of`** answers "registered but missing from keyring" in one method, reading the keyring directly so real drift stays visible.
- **`list`** enumerates registered names; a missing registry file is treated as empty.
- All keyring/IO failures surface as one **`KeyStoreError`**, so callers stop importing `keyring`.

`provider.py`, `commands/keys.py`, and `commands/status.py` now call this interface; `save_key`/`remove_key`/`list_keys`/`KEYS_PATH` move out of `config.py`.

### A real two-adapter seam
The keyring is now a genuine seam: the `keyring` module in production, an in-memory fake (`tests/fakes.py`) in tests — replacing the prior split mocking of `keyring` and `save_key`.

## Acceptance criteria

- [x] New `key_store` module owns both keyring and `keys.json`.
- [x] `add` / `remove` write both stores; no observable half-written state on failure of one side (rollback).
- [x] `get` preserves the `ANTHROPIC_API_KEY` env-var fallback.
- [x] `provider.py`, `commands/keys.py`, `commands/status.py` no longer import `keyring` directly.
- [x] Key functions removed from `config.py`.
- [x] An in-memory fake adapter backs the tests (no real keyring in unit tests).
- [x] Existing `keys add` / `keys remove` / `keys show` / `status` behaviour preserved.
- [x] TigerStyle: assertions on the invariant; functions ≤70 lines, ≤100 cols.

## Notes / judgment call

`config.initialize()` no longer pre-creates `keys.json`; the registry is created lazily on first `keys add`. Behaviour is unchanged for users since `key_store` treats a missing registry as empty. This removes a `config` → `key_store` coupling.

## Verification

- **86 tests pass** (15 new `key_store` tests; old key tests migrated off `config`/`keyring` mocking).
- `black` + `isort` clean on all touched files.
- Live smoke: `noidea keys show` → `anthropic`; `noidea status` → `API Key: ✓ anthropic (keyring)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced unified API key storage system with atomic operations and automatic rollback on partial failure to prevent inconsistent state between OS keyring and registry.

* **Bug Fixes**
  * Improved consistency and reliability of key persistence across multiple storage backends.

* **Tests**
  * Added comprehensive test coverage for key storage operations and error recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AccursedGalaxy/noidea/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->