### PR TITLE
refactor(config): collapse triple-encoded LLM config into typed LlmConfig

### DIFF
--- a/noidea/commands/status.py
+++ b/noidea/commands/status.py
@@ -3,7 +3,7 @@ import os
 from rich.console import Console
 
 from noidea import __version__
-from noidea.config import CONFIG_PATH, SERVICE_NAME, load_config
+from noidea.config import CONFIG_PATH, SERVICE_NAME, LlmConfig, load_config
 from noidea.git import HOOK_NAME, get_git_root, get_hooks_dir
 from noidea.key_store import KeyStatus, KeyStoreError, key_store
 
@@ -48,14 +48,13 @@ def _check_hook():
         )
 
 
-def _check_config() -> tuple[dict, dict]:
-    config = load_config()
-    llm = config["llm"]
+def _check_config() -> LlmConfig:
+    cfg = load_config()
     if os.path.exists(CONFIG_PATH):
         console.print(f"Config:         {OK} {CONFIG_PATH} loaded")
     else:
         console.print("Config:         [dim]using defaults[/dim]")
-    return config, llm
+    return cfg
 
 
 def _check_api_keys():
@@ -78,10 +77,10 @@ def status():
     console.print(f"\n[bold]noidea[/bold] v{__version__}\n")
     _check_repository()
     _check_hook()
-    _config, llm = _check_config()
+    cfg = _check_config()
     _check_api_keys()
-    console.print(f"Small Model:    {llm['small_model']}")
-    console.print(f"Large Model:    {llm['large_model']}")
-    console.print(f"Context Limit:  {llm['context_limit']}")
-    console.print(f"Temperature:    {llm['temperature']}")
+    console.print(f"Small Model:    {cfg.small_model}")
+    console.print(f"Large Model:    {cfg.large_model}")
+    console.print(f"Context Limit:  {cfg.context_limit}")
+    console.print(f"Temperature:    {cfg.temperature}")
     console.print()

--- a/noidea/commands/suggest.py
+++ b/noidea/commands/suggest.py
@@ -1,26 +1,29 @@
+import dataclasses
+
 import anthropic
 import typer
 from rich.console import Console
 
-from noidea.config import deep_merge, load_config
+from noidea.config import LlmConfig, load_config
 from noidea.git import get_branch_name, get_diff, get_staged_files
 from noidea.provider import get_commit_message
 
 console = Console(stderr=True)
 
 
-def _generate_message(diff, config, model, branch, staged_files) -> str | None:
+def _generate_message(diff, cfg: LlmConfig, model, branch, staged_files) -> str | None:
     """Call the API and return the commit message, or None on handled error."""
+    assert isinstance(cfg, LlmConfig), "cfg must be an LlmConfig"
     try:
         with console.status("[grey]Thinking of something clever...", spinner="dots"):
             return get_commit_message(
                 diff,
-                config["llm"]["system_prompt"],
+                cfg.system_prompt,
                 model,
-                config["llm"]["max_tokens"],
+                cfg.max_tokens,
                 branch=branch,
                 staged_files=staged_files,
-                temperature=config["llm"]["temperature"],
+                temperature=cfg.temperature,
             )
     # Errors handled here (not in provider.py) because each caller needs
     # different user-facing messages and recovery behavior.
@@ -35,13 +38,6 @@ def _generate_message(diff, config, model, branch, staged_files) -> str | None:
     except anthropic.APIStatusError as error:
         print(f"API error ({error.status_code}): {error.message}")
     return None
-
-
-def _select_model(config: dict, context_length_chars: int) -> str:
-    """Pick large or small model based on context size heuristic."""
-    if context_length_chars >= config["llm"]["context_limit"]:
-        return config["llm"]["large_model"]
-    return config["llm"]["small_model"]
 
 
 def suggest(
@@ -59,21 +55,22 @@ def suggest(
         print("Staged changes produced an empty diff. Nothing to do.")
         return
 
-    config = load_config()
+    cfg = load_config()
 
-    # CLI flag config override.
+    # CLI flag config override: both models become the requested one, so select_model
+    # returns it regardless of context size.
     if model:
-        config = deep_merge(config, {"llm": {"small_model": model, "large_model": model}})
+        cfg = dataclasses.replace(cfg, small_model=model, large_model=model)
 
     branch = get_branch_name()
     staged_files = get_staged_files()
     # Character count, not tokens: real tokenization needs the API, but char
     # count is cheap and sufficient for choosing between small and large model.
-    context_length_chars = len(config["llm"]["system_prompt"]) + len(diff.diff)
+    context_length_chars = len(cfg.system_prompt) + len(diff.diff)
 
-    selected_model = _select_model(config, context_length_chars)
+    selected_model = cfg.select_model(context_length_chars)
 
-    commit_message = _generate_message(diff.diff, config, selected_model, branch, staged_files)
+    commit_message = _generate_message(diff.diff, cfg, selected_model, branch, staged_files)
     if commit_message is None:
         return
 

--- a/noidea/commands/test.py
+++ b/noidea/commands/test.py
@@ -29,8 +29,7 @@ JOKE_TOPICS = [
 
 def test():
     """Ping the AI to make sure it's awake."""
-    config = load_config()
-    llm = config["llm"]
+    cfg = load_config()
     topic = random.choice(JOKE_TOPICS)
 
     try:
@@ -39,8 +38,8 @@ def test():
                 diff=f"tell a creative short coding joke about {topic}",
                 system_prompt="only output the joke nothing else. "
                 "be original and avoid cliché jokes.",
-                model=llm["large_model"],
-                max_tokens=llm["max_tokens"],
+                model=cfg.large_model,
+                max_tokens=cfg.max_tokens,
                 temperature=1.0,
             )
     # Same API error pattern as suggest.py, with messages suited to the test context.

--- a/noidea/config.py
+++ b/noidea/config.py
@@ -1,8 +1,10 @@
 """Three-tier configuration: built-in defaults, user overrides, repo overrides."""
 
+import dataclasses
 import json
 import os
 import sys
+from dataclasses import dataclass
 from enum import Enum
 
 from noidea.git import get_git_root
@@ -14,62 +16,99 @@ CONFIG_FILENAME = "config.json"
 CONFIG_DIR = os.path.expanduser(f"~/{CONFIG_DIR_NAME}")
 CONFIG_PATH = os.path.join(CONFIG_DIR, CONFIG_FILENAME)
 
-DEFAULTS = {
-    "llm": {
-        "max_tokens": 1024,
-        "small_model": "claude-haiku-4-5",
-        "large_model": "claude-sonnet-4-6",
-        "context_limit": 600000,  # Character threshold for model selection, not a token limit.
-        "system_prompt": (
-            "Generate a commit message from the diff, branch name, and staged files.\n"
-            "Subject: imperative mood, max 72 chars, no period, "
-            "conventional commits format (e.g. feat(scope): ..., fix(scope): ...).\n"
-            "One intent per subject — no 'and'. Use branch name to infer purpose.\n"
-            "Prefer specific verbs over generic ones (update, add, remove).\n"
-            "Body: only if the why or scope is non-obvious. "
-            "Use bullet points for multi-change commits, "
-            "one action per bullet. Keep each line under 72 chars. No fluff.\n"
-            "Output only the raw commit message."
-        ),
-        "temperature": 1.0,
-    }
-}
-
-
-_LLM_SCHEMA = {
-    "max_tokens": int,
-    "small_model": str,
-    "large_model": str,
-    "context_limit": (int, float),
-    "system_prompt": str,
-    "temperature": (int, float),
-}
+_DEFAULT_SYSTEM_PROMPT = (
+    "Generate a commit message from the diff, branch name, and staged files.\n"
+    "Subject: imperative mood, max 72 chars, no period, "
+    "conventional commits format (e.g. feat(scope): ..., fix(scope): ...).\n"
+    "One intent per subject — no 'and'. Use branch name to infer purpose.\n"
+    "Prefer specific verbs over generic ones (update, add, remove).\n"
+    "Body: only if the why or scope is non-obvious. "
+    "Use bullet points for multi-change commits, "
+    "one action per bullet. Keep each line under 72 chars. No fluff.\n"
+    "Output only the raw commit message."
+)
 
 
 class Provider(str, Enum):
     ANTHROPIC = "anthropic"
 
 
-def validate_config(config: dict) -> dict:
-    """Check config types after merge. Replace bad values with defaults."""
-    llm = config.get("llm")
-    if not isinstance(llm, dict):
-        print(
-            "Warning: config 'llm' section is not a dict, using defaults.",
-            file=sys.stderr,
-        )
-        return DEFAULTS.copy()
+@dataclass(frozen=True)
+class LlmConfig:
+    """The LLM settings, owning the field set in one place: defaults are the field defaults.
 
-    for key, expected_type in _LLM_SCHEMA.items():
-        value = llm.get(key)
-        if not isinstance(value, expected_type):
-            print(
-                f"Warning: llm.{key} has wrong type" f" ({type(value).__name__}), using default.",
-                file=sys.stderr,
-            )
-            llm[key] = DEFAULTS["llm"][key]
+    Built from a merged config dict via ``from_dict``, which coerces wrong-typed values
+    back to their default (a corrupt user config warns rather than crashes). ``__post_init__``
+    then asserts the type invariants that ``from_dict`` and the defaults both guarantee.
+    """
 
-    return config
+    max_tokens: int = 1024
+    small_model: str = "claude-haiku-4-5"
+    large_model: str = "claude-sonnet-4-6"
+    context_limit: float = 600000.0  # Character threshold for model selection, not a token limit.
+    system_prompt: str = _DEFAULT_SYSTEM_PROMPT
+    temperature: float = 1.0
+
+    def __post_init__(self):
+        # The pair to from_dict's pre-construction type check: assert the invariants
+        # after construction, so a bad dataclasses.replace is caught as a programmer error.
+        assert isinstance(self.max_tokens, int) and not isinstance(self.max_tokens, bool)
+        assert isinstance(self.small_model, str)
+        assert isinstance(self.large_model, str)
+        assert isinstance(self.context_limit, (int, float))
+        assert not isinstance(self.context_limit, bool)
+        assert isinstance(self.system_prompt, str)
+        assert isinstance(self.temperature, (int, float))
+        assert not isinstance(self.temperature, bool)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "LlmConfig":
+        """Build from a merged ``llm`` dict, falling back to the default for any bad field.
+
+        A field is "bad" when it is absent or has the wrong type; bool is never accepted for
+        a numeric field even though it is an ``int`` subclass. Each fallback warns to stderr.
+        """
+        assert isinstance(data, dict), "data must be a dict"
+        defaults = cls()
+        values = {}
+        for spec in dataclasses.fields(cls):
+            default = getattr(defaults, spec.name)
+            provided = data.get(spec.name, default)
+            if _matches_default_type(provided, default):
+                values[spec.name] = provided
+            else:
+                print(
+                    f"Warning: llm.{spec.name} has wrong type"
+                    f" ({type(provided).__name__}), using default.",
+                    file=sys.stderr,
+                )
+                values[spec.name] = default
+        result = cls(**values)
+        assert isinstance(result, LlmConfig), "from_dict must return an LlmConfig"
+        return result
+
+    def select_model(self, context_length_chars: int) -> str:
+        """Pick the large or small model based on a character-count heuristic."""
+        assert isinstance(context_length_chars, int), "context_length_chars must be an int"
+        assert context_length_chars >= 0, "context_length_chars must be non-negative"
+        if context_length_chars >= self.context_limit:
+            return self.large_model
+        return self.small_model
+
+
+def _matches_default_type(value, default) -> bool:
+    """True if ``value`` is type-compatible with ``default`` (numeric defaults accept int/float)."""
+    # bool is an int subclass but is never a valid config value, so reject it up front.
+    if isinstance(value, bool):
+        return False
+    if isinstance(default, float):
+        return isinstance(value, (int, float))
+    return isinstance(value, type(default))
+
+
+# Derived from the dataclass so the field set is enumerated exactly once. Used as the merge
+# base and written verbatim by initialize().
+DEFAULTS = {"llm": dataclasses.asdict(LlmConfig())}
 
 
 def deep_merge(base, override):
@@ -102,8 +141,10 @@ def _collect_config_paths() -> list[str]:
     return paths
 
 
-def load_config() -> dict:
-    # Merge order: defaults → user config → repo config (last wins).
+def load_config() -> LlmConfig:
+    # Merge order: defaults → user config → repo config (last wins). The merge stays
+    # dict-shaped (deep_merge handles arbitrary nested JSON); the typed LlmConfig is
+    # constructed last, from the merged dict.
     config = DEFAULTS
     for path in _collect_config_paths():
         try:
@@ -112,8 +153,14 @@ def load_config() -> dict:
         except (OSError, json.JSONDecodeError) as error:
             # Warn instead of crashing: a corrupt config should not block all CLI usage.
             print(f"Warning: could not load {path}: {error}", file=sys.stderr)
-    config = validate_config(config)
-    return config
+    llm_section = config.get("llm")
+    if not isinstance(llm_section, dict):
+        # A non-dict llm section is corrupt; fall back to an all-default config.
+        print("Warning: config 'llm' section is not a dict, using defaults.", file=sys.stderr)
+        llm_section = {}
+    cfg = LlmConfig.from_dict(llm_section)
+    assert isinstance(cfg, LlmConfig), "load_config must return an LlmConfig"
+    return cfg
 
 
 def initialize():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import anthropic
 from typer.testing import CliRunner
 
 from noidea.cli import app
+from noidea.config import LlmConfig
 from noidea.git import DiffResult, HookResult
 from noidea.key_store import KeyStoreError
 
@@ -31,16 +32,7 @@ class TestSuggest:
     @patch("noidea.commands.suggest.get_commit_message", return_value="fix: patch bug")
     @patch(
         "noidea.commands.suggest.load_config",
-        return_value={
-            "llm": {
-                "system_prompt": "gen msg",
-                "small_model": "claude-haiku-4-5",
-                "large_model": "claude-sonnet-4-6",
-                "context_limit": 600000,
-                "max_tokens": 1024,
-                "temperature": 1.0,
-            }
-        },
+        return_value=LlmConfig(system_prompt="gen msg"),
     )
     @patch(
         "noidea.commands.suggest.get_diff",
@@ -72,16 +64,7 @@ class TestSuggest:
     @patch("noidea.commands.suggest.get_commit_message", return_value="feat: new thing")
     @patch(
         "noidea.commands.suggest.load_config",
-        return_value={
-            "llm": {
-                "system_prompt": "gen msg",
-                "small_model": "claude-haiku-4-5",
-                "large_model": "claude-sonnet-4-6",
-                "context_limit": 600000,
-                "max_tokens": 1024,
-                "temperature": 1.0,
-            }
-        },
+        return_value=LlmConfig(system_prompt="gen msg"),
     )
     @patch(
         "noidea.commands.suggest.get_diff",
@@ -93,6 +76,22 @@ class TestSuggest:
         assert result.exit_code == 0
         with open(outfile) as f:
             assert f.read() == "feat: new thing"
+
+    @patch("noidea.commands.suggest.get_commit_message", return_value="fix: thing")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["file.py"])
+    @patch("noidea.commands.suggest.load_config", return_value=LlmConfig())
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ change"),
+    )
+    def test_suggest_model_override_is_used(
+        self, mock_diff, mock_config, mock_staged, mock_branch, mock_commit
+    ):
+        # --model replaces both models, so the override reaches the API regardless of size.
+        result = runner.invoke(app, ["suggest", "--model", "claude-opus-4-7"])
+        assert result.exit_code == 0
+        assert mock_commit.call_args.args[2] == "claude-opus-4-7"
 
 
 class TestTestCommand:
@@ -142,16 +141,7 @@ class TestSuggestErrors:
 
     _SUGGEST_MOCKS = {
         "noidea.commands.suggest.load_config": {
-            "return_value": {
-                "llm": {
-                    "system_prompt": "gen msg",
-                    "small_model": "claude-haiku-4-5",
-                    "large_model": "claude-sonnet-4-6",
-                    "context_limit": 600000,
-                    "max_tokens": 1024,
-                    "temperature": 1.0,
-                }
-            }
+            "return_value": LlmConfig(system_prompt="gen msg"),
         },
         "noidea.commands.suggest.get_diff": {
             "return_value": DiffResult(has_changes=True, diff="+ change"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,56 @@ import json
 from unittest.mock import patch
 
 from noidea.config import (
-    DEFAULTS,
+    LlmConfig,
     deep_merge,
     initialize,
     load_config,
-    validate_config,
 )
+
+
+class TestLlmConfig:
+    def test_defaults_match_known_values(self):
+        cfg = LlmConfig()
+        assert cfg.max_tokens == 1024
+        assert cfg.small_model == "claude-haiku-4-5"
+
+    def test_from_dict_keeps_valid_value(self):
+        cfg = LlmConfig.from_dict({"max_tokens": 512})
+        assert cfg.max_tokens == 512
+        # Untouched fields fall back to defaults.
+        assert cfg.small_model == "claude-haiku-4-5"
+
+    def test_from_dict_wrong_type_falls_back_to_default(self, capsys):
+        cfg = LlmConfig.from_dict({"max_tokens": "not a number"})
+        assert cfg.max_tokens == 1024
+        assert "Warning" in capsys.readouterr().err
+
+    def test_from_dict_missing_key_uses_default(self):
+        cfg = LlmConfig.from_dict({})
+        assert cfg.temperature == 1.0
+
+    def test_from_dict_accepts_float_context_limit(self):
+        cfg = LlmConfig.from_dict({"context_limit": 500000.0})
+        assert cfg.context_limit == 500000.0
+
+    def test_from_dict_rejects_float_max_tokens(self, capsys):
+        # max_tokens is int-only (the API wants an int); a float falls back with a warning.
+        cfg = LlmConfig.from_dict({"max_tokens": 512.5})
+        assert cfg.max_tokens == 1024
+        assert "Warning" in capsys.readouterr().err
+
+    def test_from_dict_rejects_bool_for_numeric(self):
+        # bool is an int subclass but is never a valid numeric config value.
+        cfg = LlmConfig.from_dict({"max_tokens": True})
+        assert cfg.max_tokens == 1024
+
+    def test_select_model_small_below_limit(self):
+        cfg = LlmConfig(context_limit=100)
+        assert cfg.select_model(50) == cfg.small_model
+
+    def test_select_model_large_at_limit(self):
+        cfg = LlmConfig(context_limit=100)
+        assert cfg.select_model(100) == cfg.large_model
 
 
 def _patch_paths(tmp_path):
@@ -57,7 +101,7 @@ def test_load_config_returns_defaults_after_initialize(tmp_path):
         initialize()
         result = load_config()
 
-    assert result["llm"]["max_tokens"] == 1024
+    assert result.max_tokens == 1024
 
 
 def test_load_config_user_overrides_defaults(tmp_path):
@@ -67,9 +111,9 @@ def test_load_config_user_overrides_defaults(tmp_path):
     with patch("noidea.config.CONFIG_PATH", str(config_file)), _patch_no_repo():
         result = load_config()
 
-    assert result["llm"]["max_tokens"] == 512
+    assert result.max_tokens == 512
     # defaults still present for keys not overridden
-    assert result["llm"]["small_model"] == "claude-haiku-4-5"
+    assert result.small_model == "claude-haiku-4-5"
 
 
 def test_load_config_repo_overrides_user(tmp_path):
@@ -90,8 +134,8 @@ def test_load_config_repo_overrides_user(tmp_path):
     ):
         result = load_config()
 
-    assert result["llm"]["max_tokens"] == 256
-    assert result["llm"]["small_model"] == "claude-haiku-4-5"
+    assert result.max_tokens == 256
+    assert result.small_model == "claude-haiku-4-5"
 
 
 def test_load_config_repo_partial_override(tmp_path):
@@ -108,49 +152,21 @@ def test_load_config_repo_partial_override(tmp_path):
     ):
         result = load_config()
 
-    assert result["llm"]["system_prompt"] == "Custom prompt"
-    assert result["llm"]["max_tokens"] == 1024
-    assert result["llm"]["small_model"] == "claude-haiku-4-5"
+    assert result.system_prompt == "Custom prompt"
+    assert result.max_tokens == 1024
+    assert result.small_model == "claude-haiku-4-5"
 
 
-def test_load_config_defaults_have_all_expected_keys(tmp_path):
-    p1, p2 = _patch_paths(tmp_path)
-    with p1, p2, _patch_no_repo():
-        initialize()
+def test_load_config_non_dict_llm_falls_back_to_defaults(tmp_path):
+    """A corrupt non-dict llm section yields an all-default config, not a crash."""
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"llm": "broken"}))
+
+    with patch("noidea.config.CONFIG_PATH", str(config_file)), _patch_no_repo():
         result = load_config()
 
-    assert "small_model" in result["llm"]
-    assert "large_model" in result["llm"]
-    assert "context_limit" in result["llm"]
-    assert "system_prompt" in result["llm"]
-    assert "max_tokens" in result["llm"]
-
-
-class TestValidateConfig:
-    def test_valid_config_passes_through(self):
-        result = validate_config({"llm": {**DEFAULTS["llm"]}})
-        assert result["llm"]["max_tokens"] == 1024
-
-    def test_wrong_type_falls_back_to_default(self):
-        config = {"llm": {**DEFAULTS["llm"], "max_tokens": "not a number"}}
-        result = validate_config(config)
-        assert result["llm"]["max_tokens"] == 1024
-
-    def test_non_dict_llm_returns_defaults(self):
-        result = validate_config({"llm": "broken"})
-        assert result["llm"]["max_tokens"] == 1024
-        assert result["llm"]["small_model"] == "claude-haiku-4-5"
-
-    def test_missing_key_falls_back_to_default(self):
-        config = {"llm": {**DEFAULTS["llm"]}}
-        del config["llm"]["temperature"]
-        result = validate_config(config)
-        assert result["llm"]["temperature"] == 1.0
-
-    def test_float_context_limit_accepted(self):
-        config = {"llm": {**DEFAULTS["llm"], "context_limit": 500000.0}}
-        result = validate_config(config)
-        assert result["llm"]["context_limit"] == 500000.0
+    assert result.max_tokens == 1024
+    assert result.small_model == "claude-haiku-4-5"
 
 
 class TestLoadConfigErrors:
@@ -161,7 +177,7 @@ class TestLoadConfigErrors:
         with patch("noidea.config.CONFIG_PATH", str(config_file)), _patch_no_repo():
             result = load_config()
 
-        assert result["llm"]["max_tokens"] == 1024
+        assert result.max_tokens == 1024
 
     def test_unreadable_config_falls_back_to_defaults(self, tmp_path):
         config_file = tmp_path / "config.json"
@@ -171,7 +187,7 @@ class TestLoadConfigErrors:
         try:
             with patch("noidea.config.CONFIG_PATH", str(config_file)), _patch_no_repo():
                 result = load_config()
-            assert result["llm"]["max_tokens"] == 1024
+            assert result.max_tokens == 1024
         finally:
             config_file.chmod(0o644)
 
@@ -191,7 +207,7 @@ class TestLoadConfigErrors:
         ):
             result = load_config()
 
-        assert result["llm"]["max_tokens"] == 512
+        assert result.max_tokens == 512
 
 
 class TestInitializeErrors:


### PR DESCRIPTION
Closes #17

## Problem

The LLM field set was declared **three times** in `noidea/config.py` — `DEFAULTS` (values), `_LLM_SCHEMA` (types), and the `validate_config` loop (repair) — and every caller reached into a raw `config["llm"][...]` dict by string key. A mistyped key (`config["llm"]["temprature"]`) failed at runtime, not at definition.

## Change

Return a typed, frozen `LlmConfig` dataclass from `load_config()`.

- **The field set lives in one place** — the dataclass field declarations. `DEFAULTS` is now derived via `dataclasses.asdict(LlmConfig())`; `_LLM_SCHEMA` and `validate_config` are deleted.
- **`LlmConfig.from_dict()`** does the warn-and-fall-back-to-default coercion that `validate_config` used to do (a corrupt user config warns to stderr, never crashes). `__post_init__` asserts the type invariants as the post-construction half of the pair.
- **`select_model()`** moved onto `LlmConfig` (was `suggest._select_model`).
- **`deep_merge` retained, unchanged.** `load_config` still merges raw dicts (defaults → user → repo) and constructs the typed object **last**, at the boundary.
- **`--model` override** switches from `deep_merge` to `dataclasses.replace(cfg, small_model=model, large_model=model)`.
- **Consumers** (`suggest`, `status`, `test`) read typed attributes (`cfg.system_prompt`, `cfg.max_tokens`, …). Tests stop hand-building nested `{"llm": {...}}` dicts and use `LlmConfig(...)` directly.

## Acceptance criteria

- [x] `load_config()` returns a typed `LlmConfig`
- [x] `DEFAULTS` and `_LLM_SCHEMA` no longer redundantly enumerate the field set
- [x] Corrupt/wrong-type config still warns and falls back (no crash)
- [x] Three-tier merge tests still pass; `deep_merge` retained
- [x] `suggest`, `status`, `test` read typed attributes
- [x] TigerStyle: invariant assertions on `LlmConfig`, functions ≤70 lines, ≤100 cols

## Behaviour note

The `context_limit` default is now `600000.0` (float, was int `600000`) so `from_dict` accepts float values for it (matching the old `_LLM_SCHEMA` `(int, float)`). Fresh installs show `Context Limit: 600000.0` in `noidea status`; existing int configs are unaffected.

## Testing

- 91 tests pass (`poetry run pytest`), up from 86 — `TestValidateConfig` rewritten as `TestLlmConfig` against `from_dict`, plus a new `--model` override test.
- `black` / `isort` / `pyright` clean.
- Manually verified `noidea status` and the corrupt-`llm`-section fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)