### PR TITLE
feat: repo-native commit style learning + PyPI discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,17 @@ Precedence: built-in defaults → user config → repo config.
     "large_model": "claude-sonnet-4-6",
     "context_limit": 600000,
     "temperature": 1.0,
+    "learn_commit_style": true,
     "system_prompt": "Your custom prompt here"
   }
 }
 ```
 
 Falls back to built-in defaults if no config file exists. The default prompt follows conventional commits style (`feat`/`fix`/`refactor`/etc.) with a 72-character subject line limit. Smaller diffs use `small_model` (Haiku) for speed; larger diffs automatically switch to `large_model` (Sonnet). `temperature` controls output creativity (0.0–1.0); the default of `1.0` maximises variety.
+
+### Repo-native style learning
+
+`learn_commit_style` (on by default) samples your recent `git log` and matches the repo's own conventions — its scope vocabulary, whether commits carry a body, typical subject length, and gitmoji usage — so suggestions read like your project's existing commits rather than generic boilerplate. It activates automatically once a repo has at least 5 commits; below that it stays out of the way. Set `"learn_commit_style": false` to disable it.
 
 ## Contributing
 

--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -1,0 +1,99 @@
+# noidea — Competitive & SEO Analysis
+
+> Companion to [discoverability-plan.md](discoverability-plan.md). Dated 2026-05-22.
+> Diagnosis stands: the code is good; **reach, positioning, and a sharp differentiator**
+> are what's missing. This doc supplies the feature comparison and names two features to
+> own.
+
+---
+
+## 1. The field (what we're up against)
+
+| Tool | Lang | Stars (~2026) | Install | Providers (local?) | Editor-prefill hook | Standalone cmd | Multi-suggestion | Conventional | Gitmoji | Body |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **aicommits** (Nutlope) | TS | ~9k | npm | TogetherAI/OpenAI/Groq/xAI/OpenRouter/**Ollama**/LM Studio (yes) | Yes | Yes | Yes | Yes | Yes | Yes |
+| **opencommit** (`oco`) | JS/TS | ~7.3k | npm, **GH Action** | OpenAI/Anthropic/Azure/**Ollama**/Gemini/DeepSeek (yes) | Yes | Yes | No | Yes (+commitlint) | Yes | Yes |
+| **aicommit2** | TS | ~0.5k | npm, **brew**, Nix | 11+ incl. Anthropic/**Ollama** (yes) | Yes | Yes (parallel race) | Yes | Yes | Yes | Yes |
+| **gptcommit** | **Rust** | ~2.4k | cargo, **brew** | **OpenAI only** (no) | **Yes (hook-first)** | No | No | Yes | No | Yes (per-file) |
+| **czg / cz-git AI** | TS | (big Commitizen base) | npm | OpenAI/DeepSeek/GH Models/**Ollama** (yes) | No (wizard) | Yes | Yes | Yes (core) | via cz-git | subject |
+| **ai-commit** (Go) | **Go** | low | curl, go | OpenAI/Gemini/Anthropic/DeepSeek/**Ollama**/OpenRouter (yes) | unknown | Yes (TUI) | Yes | Yes | Yes | Yes |
+| **lazycommit** | TS | low 100s | npm | **Groq** only | Yes | Yes | Yes | Yes | ? | ? |
+| **Cursor / Copilot** (IDE) | n/a | n/a | bundled | subscription | n/a | UI button | No | partial | No | Yes |
+| **→ noidea** | **Py** | **0** | **pipx/pip** | **Anthropic only** | **Yes (hook-first)** | `suggest` prints | No | Yes | No | Yes (when non-obvious) |
+
+### What this tells us
+
+- **Ollama / local models are table stakes**, not a differentiator. Five of eight support it. noidea's Anthropic-only stance is the single biggest *try-it blocker* (you need a paid key to even test it) — Phase 1 of the discoverability plan is correctly prioritized. But shipping Ollama only reaches **parity**; it wins nothing on its own.
+- **Conventional commits + gitmoji + body** are commodity features. Everyone has them.
+- **The crowded lane is "command-first, propose-and-commit, many providers."** aicommits and opencommit own it on star authority; aicommit2 out-features everyone (parallel multi-model racing, pre-commit code review, multi-VCS jj/yadm) but stays small at ~500 stars — proving features alone don't convert.
+- **The real 2026 threat is not a CLI.** Cursor / Copilot / Windsurf generate commit messages zero-config, free with subscription, inside the editor. Standalone CLIs survive only on a terminal-native, hook-driven, privacy/cost-aware workflow. That's the niche to lead with — not "another AI commit CLI."
+
+---
+
+## 2. SEO & discoverability position
+
+**The name is the core liability.** "noidea" carries zero category keywords (no *commit* / *git* / *ai*) and collides hard with unrelated brands (No Idea Records, No Idea Festival, NOIDEA fashion). A bare Google "noidea" returns *none* of our tool on page 1. Every competitor that ranks is self-describing — **ai**commits, **open**commit, **ai-commit**, autocommit — the name *is* the keyword. We will never win organic search on the name; we must carry keywords everywhere the name can't.
+
+- **Page-1 anchor for every head term is `aicommits`.** It's the brand to beat and shows up on "ai commit message generator," "...cli," "best ai commit tools 2025," etc.
+- **Recurring listicle tools:** aicommits, opencommit, czg, Copilot, Cursor. noidea appears in **none**. Authors need (a) stars and (b) a one-line hook. We have neither yet — section 4 fixes (b).
+- **What actually drove competitor growth:** aicommits = author's large X audience + a ~60-point Show HN; opencommit = **GitHub 2023 Hackathon win** (cited in every listicle) + a modest Product Hunt. Product Hunt was minor; Reddit-driven growth was **not verifiable** for either. Lacking an author audience, our realistic levers are a strong Show HN + a one-line differentiator a listicle author can quote.
+- **Legacy footprint drift:** `pkg.go.dev` still indexes the *old Go* noidea, and an April 2025 Medium post frames it as a "sassy Moai AI Git sidekick." That fragments our identity vs. the current serious Python/Claude tool. Worth cleaning up.
+
+### ✅ Resolved 2026-05-22: Phase 0 PyPI metadata now shipped
+
+> The discoverability plan had marked this `[x] done`, but `pyproject.toml` actually had
+> none of it (description was `"You have no idea what to write? We've got you."` — zero
+> keywords). It is now genuinely shipped: keyword-rich `description`, `keywords`,
+> `classifiers`, and `[project.urls]` are in `pyproject.toml` (verified in the built wheel
+> METADATA; `poetry check` clean, license modernized to the SPDX `MIT` expression). The
+> original recommendation, for the record:
+
+- `keywords = ["git", "commit", "ai", "conventional-commits", "cli", "claude", "anthropic", "prepare-commit-msg", "commit-message-generator", "developer-tools"]`
+- full `classifiers` (Topic :: Software Development :: Version Control :: Git, etc.)
+- `[project.urls]` (Homepage, Repository, Issues)
+- keyword-rich `description`, e.g. *"AI commit messages that pre-fill your git editor — Claude-powered, conventional-commits aware."*
+
+GitHub topics are also thin (`ai`, `git`, `git-hooks`, `llm`). Add the category-defining ones: `ai-commit`, `commit-message-generator`, `conventional-commits`, `git-commit`, `cli`, `anthropic`, `claude`, `pre-commit-hook`.
+
+---
+
+## 3. The two features to own
+
+The brief: *find two features no one else has or does right.* Both below are (a) verified white space against the field in §1, (b) aligned with noidea's existing architecture and its safety-first TigerStyle ethos, and (c) one-line quotable for a listicle.
+
+### Feature 1 — Repo-native style learning ("commits that look like your team's")
+
+**The gap.** Every tool generates *generic* conventional-commit messages from a static, hard-coded system prompt. opencommit's commitlint integration only *enforces rules you hand-write*; nobody **learns the repository's actual conventions automatically.** Real repos have a voice — a scope vocabulary (`feat(provider):`, `fix(cli):`), a body habit (always / never / only-when-non-obvious), a subject length, gitmoji or not. AI tools ignore all of it and produce messages that read like a bot dropped in.
+
+**What noidea would do.** Before generating, sample recent `git log` (subjects + bodies) and infer the repo's conventions, then condition the prompt on them: reuse the scope vocabulary already in use, match body style, match subject length, mirror gitmoji usage. Result: messages that match what the project already commits, not a generic template.
+
+**Why noidea specifically.** We already build `_build_user_content` from branch + staged files, and the prompt is config-driven and overridable. Adding a `git log` sample to that context is a natural, small extension of the existing pipeline — and it lands squarely in the **prefill-the-editor-then-you-decide** model, where matching house style matters most.
+
+**One-liner:** *"noidea reads how your repo already commits and writes in that voice — not generic AI boilerplate."* That's a sentence a listicle author can quote, and no competitor can.
+
+### Feature 2 — Cost-aware automatic model routing (we already have it — sharpen and *market* it)
+
+**The gap.** Competitors use one configured model for every commit. None route per-commit by how much thinking the diff actually needs. aicommit2 races *all* providers in parallel — the opposite trade-off: maximum cost for every commit.
+
+**What noidea already does.** `LlmConfig.select_model()` sends small diffs to a fast/cheap model (Haiku) and escalates large diffs to a stronger one (Sonnet) automatically (`config.py:90`). This is **genuinely unique in the field** and currently buried in the config docs instead of being a headline.
+
+**How to do it *right* (it's currently crude).** Routing is a raw character count vs. a fixed threshold. Sharpen it into a real feature:
+- Route on signal, not just size — number of files, new-file vs. edit, test-only vs. source, lockfile-only.
+- Make the escalation **visible** ("small diff → fast model" / "large change → escalating to the strong model") so the value is felt.
+- Surface the trade-off in the pitch: trivial commits cost ~nothing and return instantly; only substantial changes pay for the strong model.
+
+**One-liner:** *"Spends pennies and milliseconds on trivial commits; brings out the big model only when the diff actually earns it."* Pairs perfectly with the privacy/cost angle that's the standalone CLI's whole reason to exist against Copilot/Cursor.
+
+### Supporting positioning lever (not unique enough to headline)
+
+**"Never auto-commits — you always get the last word."** noidea (and gptcommit) prefill the editor and never commit for you, unlike the command-first majority that commit on confirm. It's a real trust differentiator that fits TigerStyle's safety-first ethos and the Show HN body already drafted — but gptcommit shares it, so use it as *reinforcement*, not the headline.
+
+---
+
+## 4. Recommended sequence
+
+1. **Ship the unclaimed Phase 0 SEO** (pyproject keywords/classifiers/urls/description + GitHub topics). Free, do it this week, before the next release render.
+2. **Build Feature 1 (repo-native style learning)** via grill-the-plan → TDD. This is the differentiator a listicle quotes and the thing Cursor/Copilot structurally *can't* market against a hook tool.
+3. **Promote Feature 2 (cost-aware routing) to a headline** — sharpen the heuristic, make escalation visible, put it in the README's "Why noidea?" section.
+4. **Close the Ollama gap (Phase 1)** for parity / try-it-without-a-key — necessary, not sufficient.
+5. **Then launch** (Phase 3) with two quotable, defensible lines no incumbent has: *repo-native voice* + *cost-aware routing*.

--- a/docs/discoverability-plan.md
+++ b/docs/discoverability-plan.md
@@ -1,0 +1,98 @@
+# noidea Discoverability Plan
+
+> Working doc. Diagnosis: the code is fine; **reach and positioning are the problem.**
+> Stars = reach × conversion, and reach is currently ~0. This plan fixes both, in order.
+
+## Guiding principle
+
+You get **one** Show HN and one "first impression" per channel. Do not spend them
+until (a) the multi-provider gap is closed and (b) the conversion surfaces (README,
+PyPI page, social preview) are sharp. Launching Anthropic-only invites the
+"why not Ollama/OpenAI?" top comment that kills momentum.
+
+---
+
+## Phase 0 — Quick wins (do now, minutes)
+
+- [x] **PyPI metadata** — added `keywords`, full `classifiers`, `[project.urls]`,
+  keyword-rich `description` in `pyproject.toml`. Ships on next release.
+- [x] **README repositioning** — H1 now leads with the function; added a "Why noidea?"
+  section that differentiates honestly against aicommits/opencommit.
+- [ ] **GitHub topics** — run:
+  ```bash
+  gh repo edit AccursedGalaxy/noidea \
+    --add-topic commit --add-topic commit-messages --add-topic git-commit \
+    --add-topic conventional-commits --add-topic cli --add-topic command-line \
+    --add-topic python --add-topic anthropic --add-topic claude \
+    --add-topic developer-tools --add-topic prepare-commit-msg --add-topic productivity
+  ```
+- [ ] **Custom OpenGraph image** — repo currently uses GitHub's default gray preview.
+  A 1280×640 PNG with the name + one-line value prop makes every shared link look
+  intentional. Upload via repo Settings → Social preview.
+- [ ] **Enable Discussions** — a low-friction place for "how do I…" that doesn't clutter
+  Issues, and a signal the project is alive.
+
+## Phase 1 — Close the credibility gap (the gating build)
+
+**Multi-provider support (OpenAI + Ollama).** This is the single biggest functional
+gap vs. every incumbent, and the #1 try-it blocker: today you cannot even *try* noidea
+without a paid Anthropic key. Ollama removes that blocker entirely (free + local).
+
+- Recommended approach: go through grill-the-plan → TDD red-green-refactor (project
+  workflow). Treat it as a `Provider` abstraction behind the existing `complete()`
+  transport, with Anthropic / OpenAI / Ollama implementations and config-driven
+  selection. Keep TigerStyle (assertions, ≤70-line functions, explicit errors).
+- README + docs then say "works with Claude, GPT, and local Ollama models" — which is
+  the line that makes the launch land.
+
+## Phase 2 — Widen install paths
+
+- [ ] **GitHub Action** — publish a `noidea` Action to the Marketplace. opencommit's
+  Action is a real discovery surface; the Marketplace is searchable and indexed.
+- [ ] **Homebrew formula** — `brew install noidea`. Removes the "is pipx even installed?"
+  friction for Mac users.
+- [ ] Keep pipx/pip as the primary path; these are additive.
+
+## Phase 3 — Launch (one shot — do it well)
+
+Prerequisite: Phases 0–1 done, demo GIF current, README sharp.
+
+### Show HN
+- Title: `Show HN: noidea – AI git commit messages that pre-fill your editor (Claude/GPT/Ollama)`
+- Post body (draft):
+  > I kept writing lazy one-word commit messages, so I built noidea. After a one-time
+  > `noidea init`, every `git commit` opens your editor with a suggested message already
+  > filled in from your staged diff — no new command, and it never auto-commits, so you
+  > always get the last word. Small diffs use a fast/cheap model; large diffs escalate
+  > automatically. Works with Claude, GPT, and local Ollama. It's a small Python CLI,
+  > MIT, built to a strict safety-first style guide. Feedback welcome — especially on
+  > the prompt and the model-switching heuristic.
+- Post Tue–Thu, ~8–10am ET. Reply to every comment in the first 2 hours.
+
+### Reddit
+- r/programming, r/git, r/commandline, r/Python. **Different framing per sub** — no
+  cross-posting the same text. Lead with the problem, not the tool. Link the repo, not a
+  blog. Be present in comments.
+
+## Phase 4 — Slow-burn durable discovery
+
+- [ ] **Awesome-list PRs** (durable backlinks + SEO):
+  - `agarrharr/awesome-cli-apps` (Git section)
+  - `dictcp/awesome-git` / `git-tips`-style lists
+  - `sindresorhus/awesome` adjacent dev-tool lists
+  - any "awesome-claude" / "awesome-llm-tools" lists
+  - Each PR: one clean line, alphabetical, matches the list's format exactly.
+- [ ] **Comparison SEO** — a short "noidea vs aicommits vs opencommit" section in docs
+  captures the high-intent search traffic ("ai commit tool comparison").
+
+---
+
+## Scorecard (revisit monthly)
+
+| Signal | Baseline (2026-05-22) | Target 90d |
+|--------|----------------------|-----------|
+| GitHub stars | 0 | 100+ |
+| PyPI monthly downloads | ~unknown | 500+ |
+| Providers supported | 1 (Anthropic) | 3 (Anthropic/OpenAI/Ollama) |
+| Install paths | pipx/pip | + Homebrew + Action |
+| Awesome-list entries | 0 | 3+ |

--- a/docs/style-learning-plan.md
+++ b/docs/style-learning-plan.md
@@ -1,0 +1,127 @@
+# Plan: Repo-native commit style learning
+
+> Grilled 2026-05-22. Differentiator #1 from [competitive-analysis.md](competitive-analysis.md):
+> noidea reads how a repo already commits and writes in that voice, instead of generic
+> conventional-commit boilerplate.
+>
+> **Status: implemented 2026-05-22** via TDD (20 new tests across `test_style.py`,
+> `test_git.py`, `test_config.py`, `test_cli.py`; full suite 117 green, black/isort/pyright
+> clean). Code lives in `noidea/style.py` (analysis + render), `noidea/git.py`
+> (`Commit`, `get_recent_commits`), `noidea/config.py` (`learn_commit_style`), and
+> `noidea/commands/suggest.py` (`_learn_style` wiring). Follow-up idea: rank `scopes` by
+> frequency and cap to the top ~8 to keep the hint compact on repos with many scopes.
+
+## What it does
+
+Before generating, sample recent `git log`, distil the repo's conventions into a typed
+`StyleProfile`, render it as a `Repo commit conventions:` block, and add it to the user
+content alongside the existing branch/staged-files context. The model then matches the
+repo's voice. Self-disables on thin history; never breaks `git commit`.
+
+## Resolved decisions (the grill)
+
+1. **Representation — structured profile**, not raw examples. A `StyleProfile` dataclass
+   distilled from the log. Deterministic, unit-testable with zero API calls, token-compact,
+   inspectable.
+2. **Injection — user content.** A `Repo commit conventions:` section in
+   `_build_user_content`, parallel to `Branch:`/`Staged files:`. Leaves the user-overridable
+   `system_prompt` untouched; no collision logic.
+3. **Precedence — quality floor + conventional toggle.** The default rules stay the quality
+   floor (imperative, one-intent). Subject length **tightens only** (`min(72, median)`).
+   Scope vocab and gitmoji are additive. Body habit may loosen (an extra body is never a
+   quality regression). The one honored contradiction: if the repo demonstrably does **not**
+   use conventional commits, drop the `type(scope):` prefix to match it.
+4. **Sampling — last 50 commits, `--no-merges`, all authors**, no bot filtering in v1.
+   Single fast `git log` call, ~80 prompt tokens, zero API cost.
+5. **Threshold + safety — min 5 commits; never raise.** Below 5 → omit the section →
+   identical to today. The extraction is best-effort (`check=False` pattern, returns `None`
+   on any failure) because `prepare-commit-msg` aborts the commit on a non-zero exit. Fresh
+   repo, shallow clone, and git failure all land on the safe today-behavior path.
+6. **Config — on-by-default + one boolean kill-switch.** `learn_commit_style: bool = True`
+   in `LlmConfig`. No size/threshold knobs in v1 (YAGNI).
+
+## Module layout
+
+- **`noidea/git.py`** (raw retrieval, matches its "structured dataclasses" charter):
+  - `@dataclass Commit` — `subject: str`, `body: str`.
+  - `get_recent_commits(count: int = 50) -> list[Commit]` — `git log -n {count} --no-merges
+    --format='%s%x1f%b%x1e'`, `check=False`, returns `[]` on any failure (never raises).
+- **`noidea/style.py`** (new; pure analysis + rendering):
+  - `@dataclass(frozen=True) StyleProfile` with `__post_init__` invariant assertions:
+    - `scopes: tuple[str, ...]` — observed conventional scopes, by frequency.
+    - `conventional_ratio: float` (0–1) — subjects matching the conventional regex.
+    - `body_ratio: float` (0–1) — commits with a non-empty body.
+    - `subject_length_chars_median: int`.
+    - `uses_gitmoji: bool`.
+  - `analyze_commits(commits: list[Commit]) -> StyleProfile | None` — pure; `None` when
+    `len(commits) < MIN_COMMITS`.
+  - `render_profile(profile: StyleProfile) -> str` — pure; applies the §3 precedence.
+  - Constants: `SAMPLE_SIZE = 50`, `MIN_COMMITS = 5`, `CONVENTIONAL_THRESHOLD = 0.7`,
+    body bands (`>=0.5` include / `<=0.15` omit / else percentage), conventional + gitmoji
+    regexes.
+- **`noidea/config.py`** — add `learn_commit_style: bool = True` to `LlmConfig`
+  (`from_dict` coercion + `__post_init__` assertion handle it like every other field).
+- **`noidea/commands/suggest.py`** — wire it in; `_build_user_content` gains a
+  `profile_text: str = ""` param and inserts the section between staged files and the diff.
+
+No import cycle: `config` already imports `git`; `style` imports `Commit` from `git`;
+`suggest` imports both. `StyleProfile` lives in `style`, not `config`.
+
+### Render mapping (§3 made concrete)
+
+- `conventional_ratio >= 0.7` → "use conventional format; scopes used here: …" ;
+  else → "this repo does not use conventional-commit prefixes — match its plain style."
+- subject → "aim for ~`min(72, subject_length_chars_median)` characters."
+- body → high: "most commits include a short body"; low: "commits rarely include a body";
+  mid: "~X% include a body."
+- `uses_gitmoji` → "this repo prefixes subjects with a gitmoji — do the same."
+
+(Thresholds 0.7 / 0.5 / 0.15 are internal constants, tunable later.)
+
+## TDD sequence (red → green → refactor)
+
+**Pure analysis — `analyze_commits` (no I/O, canned `list[Commit]`):**
+1. returns `None` below `MIN_COMMITS` (4 commits).
+2. `conventional_ratio` from a mix of conventional + plain subjects.
+3. `scopes` extracted and deduped from conventional subjects.
+4. `body_ratio` from commits with/without bodies.
+5. `subject_length_chars_median` correct for odd/even counts.
+6. `uses_gitmoji` true/false on emoji-prefixed vs plain subjects.
+7. `StyleProfile.__post_init__` rejects out-of-range ratios.
+
+**Pure rendering — `render_profile`:**
+8. high conventional_ratio → instructs conventional format + lists scopes.
+9. low conventional_ratio → "no prefix, plain style."
+10. subject tightens (median 50 → "~50") but never loosens (median 90 → "~72").
+11. body bands: high → include, low → omit, mid → percentage.
+12. `uses_gitmoji` → mentions gitmoji.
+
+**Retrieval — `get_recent_commits` (mock `subprocess.run`, per `test_git.py`):**
+13. parses `%s\x1f%b\x1e` output into `Commit` list (multi-line bodies intact).
+14. returns `[]` on subprocess failure — never raises.
+15. invokes `--no-merges` and `-n {count}`.
+
+**Config:**
+16. `LlmConfig()` default `learn_commit_style is True`.
+17. `from_dict` coerces a non-bool `learn_commit_style` to default with a warning.
+
+**Integration — `_build_user_content` + `suggest` (via `runner.invoke`, patches):**
+18. `_build_user_content` includes the section when `profile_text` is non-empty.
+19. `_build_user_content` omits it when `profile_text` is empty.
+20. `suggest` with `learn_commit_style=False` never calls `get_recent_commits`.
+21. `suggest` with style on + sufficient history injects the profile into the content
+    passed to `complete`.
+22. `suggest` still succeeds when `get_recent_commits` returns `[]` (profile `None` → no
+    section) — the degrade path.
+
+## TigerStyle checklist
+
+- Every function ≤70 lines, ≤100 cols, `snake_case`, ≥2 assertions (args + return/invariant).
+- `get_recent_commits` best-effort like the existing git wrappers; explicit error handling.
+- No recursion; bounded loops over the sampled commits.
+- Comments say *why* (e.g., why tighten-only on subject length; why never-raise).
+
+## Out of scope (v1)
+
+Bot-author filtering, `--mine` author scoping, configurable sample size/threshold, raw-example
+hybrid, learned-style caching across invocations.

--- a/noidea/commands/suggest.py
+++ b/noidea/commands/suggest.py
@@ -4,8 +4,9 @@ import typer
 from rich.console import Console
 
 from noidea.config import LlmConfig, load_config
-from noidea.git import get_branch_name, get_diff, get_staged_files
+from noidea.git import get_branch_name, get_diff, get_recent_commits, get_staged_files
 from noidea.provider import ErrorKind, ProviderError, complete
+from noidea.style import SAMPLE_SIZE, analyze_commits, render_profile
 
 console = Console(stderr=True)
 
@@ -20,15 +21,21 @@ SUGGEST_WORDING = {
 assert set(SUGGEST_WORDING) == set(ErrorKind), "SUGGEST_WORDING must cover every ErrorKind"
 
 
-def _build_user_content(diff: str, branch: str, staged_files: list[str]) -> str:
+def _build_user_content(
+    diff: str, branch: str, staged_files: list[str], profile_text: str = ""
+) -> str:
     """Assemble the user message from git context. The only commit-specific logic, kept pure."""
     assert isinstance(diff, str), "diff must be a string"
     assert isinstance(staged_files, list), "staged_files must be a list"
+    assert isinstance(profile_text, str), "profile_text must be a string"
     context_parts = []
     if branch:
         context_parts.append(f"Branch: {branch}")
     if staged_files:
         context_parts.append("Staged files:\n" + "\n".join(f"- {f}" for f in staged_files))
+    # The learned conventions sit with the other context, before the diff.
+    if profile_text:
+        context_parts.append(profile_text)
     user_content = ""
     if context_parts:
         user_content = "\n".join(context_parts) + "\n\nDiff:\n"
@@ -37,11 +44,28 @@ def _build_user_content(diff: str, branch: str, staged_files: list[str]) -> str:
     return user_content
 
 
-def _generate_message(diff, cfg: LlmConfig, model, branch, staged_files) -> str | None:
+def _learn_style(cfg: LlmConfig) -> str:
+    """Distil the repo's commit conventions into a prompt block, or "" if off/insufficient.
+
+    Best-effort: get_recent_commits never raises and analyze_commits returns None below the
+    minimum sample, so this degrades to "" (today's behavior) rather than blocking a commit.
+    """
+    assert isinstance(cfg, LlmConfig), "cfg must be an LlmConfig"
+    if not cfg.learn_commit_style:
+        return ""
+    profile = analyze_commits(get_recent_commits(SAMPLE_SIZE))
+    profile_text = render_profile(profile) if profile is not None else ""
+    assert isinstance(profile_text, str), "profile_text must be a string"
+    return profile_text
+
+
+def _generate_message(
+    diff, cfg: LlmConfig, model, branch, staged_files, profile_text
+) -> str | None:
     """Call the API and return the commit message, or None on a handled provider error."""
     assert isinstance(cfg, LlmConfig), "cfg must be an LlmConfig"
     assert isinstance(model, str) and model, "model must be a non-empty string"
-    user_content = _build_user_content(diff, branch, staged_files)
+    user_content = _build_user_content(diff, branch, staged_files, profile_text)
     # complete() raises one ProviderError; wording per kind stays local to this command.
     try:
         with console.status("[grey]Thinking of something clever...", spinner="dots"):
@@ -81,13 +105,16 @@ def suggest(
 
     branch = get_branch_name()
     staged_files = get_staged_files()
+    profile_text = _learn_style(cfg)
     # Character count, not tokens: real tokenization needs the API, but char
     # count is cheap and sufficient for choosing between small and large model.
     context_length_chars = len(cfg.system_prompt) + len(diff.diff)
 
     selected_model = cfg.select_model(context_length_chars)
 
-    commit_message = _generate_message(diff.diff, cfg, selected_model, branch, staged_files)
+    commit_message = _generate_message(
+        diff.diff, cfg, selected_model, branch, staged_files, profile_text
+    )
     if commit_message is None:
         return
 

--- a/noidea/config.py
+++ b/noidea/config.py
@@ -48,6 +48,7 @@ class LlmConfig:
     context_limit: float = 600000.0  # Character threshold for model selection, not a token limit.
     system_prompt: str = _DEFAULT_SYSTEM_PROMPT
     temperature: float = 1.0
+    learn_commit_style: bool = True  # Match the repo's observed commit conventions.
 
     def __post_init__(self):
         # The pair to from_dict's pre-construction type check: assert the invariants
@@ -60,6 +61,7 @@ class LlmConfig:
         assert isinstance(self.system_prompt, str)
         assert isinstance(self.temperature, (int, float))
         assert not isinstance(self.temperature, bool)
+        assert isinstance(self.learn_commit_style, bool)
 
     @classmethod
     def from_dict(cls, data: dict) -> "LlmConfig":
@@ -98,7 +100,10 @@ class LlmConfig:
 
 def _matches_default_type(value, default) -> bool:
     """True if ``value`` is type-compatible with ``default`` (numeric defaults accept int/float)."""
-    # bool is an int subclass but is never a valid config value, so reject it up front.
+    # A bool default (e.g. learn_commit_style) accepts only a bool.
+    if isinstance(default, bool):
+        return isinstance(value, bool)
+    # bool is an int subclass but is never a valid value for a numeric/str field, so reject it.
     if isinstance(value, bool):
         return False
     if isinstance(default, float):
@@ -156,7 +161,10 @@ def load_config() -> LlmConfig:
     llm_section = config.get("llm")
     if not isinstance(llm_section, dict):
         # A non-dict llm section is corrupt; fall back to an all-default config.
-        print("Warning: config 'llm' section is not a dict, using defaults.", file=sys.stderr)
+        print(
+            "Warning: config 'llm' section is not a dict, using defaults.",
+            file=sys.stderr,
+        )
         llm_section = {}
     cfg = LlmConfig.from_dict(llm_section)
     assert isinstance(cfg, LlmConfig), "load_config must return an LlmConfig"

--- a/noidea/git.py
+++ b/noidea/git.py
@@ -7,6 +7,14 @@ from dataclasses import dataclass
 
 
 @dataclass
+class Commit:
+    """One sampled commit, split into its subject line and the remaining body."""
+
+    subject: str
+    body: str = ""
+
+
+@dataclass
 class DiffResult:
     has_changes: bool
     diff: str = ""
@@ -52,6 +60,50 @@ def get_branch_name() -> str:
         check=False,
     )
     return result.stdout.strip()
+
+
+# git log format separators: US (0x1f) between subject and body, RS (0x1e) between records.
+# These bytes never occur in commit text, so they parse unambiguously.
+_FIELD_SEP = "\x1f"
+_RECORD_SEP = "\x1e"
+
+
+def get_recent_commits(count: int) -> list[Commit]:
+    """Return up to ``count`` recent non-merge commits as Commit objects (subject + body).
+
+    Best-effort like the other wrappers: any failure (shallow clone, git missing, parse
+    surprise) returns an empty list rather than raising, so the commit hook never breaks.
+    """
+    assert isinstance(count, int) and count > 0, "count must be a positive integer"
+    # check=False + catching FileNotFoundError: a degraded result must fall back to no style
+    # profile, never abort a commit. git missing entirely is just another empty result.
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "-n",
+                str(count),
+                "--no-merges",
+                f"--format=%s{_FIELD_SEP}%b{_RECORD_SEP}",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0:
+        return []
+    commits: list[Commit] = []
+    for record in result.stdout.split(_RECORD_SEP):
+        record = record.strip("\n")
+        if not record:
+            continue
+        subject, _, body = record.partition(_FIELD_SEP)
+        commits.append(Commit(subject=subject.strip(), body=body.strip()))
+    assert isinstance(commits, list), "get_recent_commits must return a list"
+    return commits
 
 
 def get_staged_files() -> list[str]:

--- a/noidea/style.py
+++ b/noidea/style.py
@@ -28,8 +28,14 @@ _CONVENTIONAL_RE = re.compile(r"^(\w+)(?:\(([^)]+)\))?!?: ")
 
 # A gitmoji prefix: either a :shortcode: or a leading emoji from the common emoji blocks
 # (misc symbols/dingbats U+2600-27BF, misc symbols-and-arrows U+2B00-2BFF, and the
-# supplementary emoji plane U+1F000-1FAFF that covers most gitmoji).
-_GITMOJI_RE = re.compile(r"^\s*(?::[a-z0-9_+-]+:|[☀-➿⬀-⯿\U0001f000-\U0001faff])")
+# supplementary emoji plane U+1F000-1FAFF that covers most gitmoji). The base emoji may carry
+# trailing variation selectors / ZWJ / skin-tone modifiers (e.g. ♻️, ⚡️), which we consume so
+# the conventional check downstream sees a clean type, not an invisible leading codepoint.
+# U+FE0E/U+FE0F variation selectors, U+200D zero-width joiner, U+1F3FB-1F3FF skin tones.
+_GITMOJI_RE = re.compile(
+    r"^\s*(?::[a-z0-9_+-]+:"
+    r"|[☀-➿⬀-⯿\U0001f000-\U0001faff][\ufe0e\ufe0f\u200d\U0001f3fb-\U0001f3ff]*)"
+)
 
 # A repo "uses gitmoji" only when the habit is dominant, not when one commit slipped one in.
 _GITMOJI_RATIO_MIN = 0.5
@@ -42,6 +48,20 @@ CONVENTIONAL_THRESHOLD = 0.7
 # does; between, we state the observed share rather than push either way.
 _BODY_RATIO_HIGH = 0.5
 _BODY_RATIO_LOW = 0.15
+
+
+def _strip_gitmoji_prefix(subject: str) -> str:
+    """Drop a leading gitmoji (emoji or :shortcode:) and its trailing space from a subject.
+
+    A subject like '✨ feat(cli): x' is conventional underneath the emoji, but \\w in the
+    conventional regex cannot match an emoji, so we peel the prefix off first. Subjects with
+    no gitmoji are returned unchanged.
+    """
+    assert isinstance(subject, str), "subject must be a string"
+    match = _GITMOJI_RE.match(subject)
+    stripped = subject[match.end() :].lstrip() if match else subject
+    assert isinstance(stripped, str), "stripped subject must be a string"
+    return stripped
 
 
 def _median_int(values: list[int]) -> int:
@@ -93,7 +113,9 @@ def analyze_commits(commits: list[Commit]) -> StyleProfile | None:
             body_count += 1
         if _GITMOJI_RE.match(commit.subject):
             gitmoji_count += 1
-        match = _CONVENTIONAL_RE.match(commit.subject)
+        # Peel any leading gitmoji first so a '✨ feat(cli): x' subject still reads as
+        # conventional and its scope is captured, instead of being scored as plain.
+        match = _CONVENTIONAL_RE.match(_strip_gitmoji_prefix(commit.subject))
         if match:
             conventional_count += 1
             scope = match.group(2)

--- a/noidea/style.py
+++ b/noidea/style.py
@@ -1,0 +1,160 @@
+"""Repo-native commit style learning: distil recent commits into a StyleProfile.
+
+The analysis is pure (no git, no API), so it is unit-testable with canned commits.
+suggest() renders the profile into the prompt so generated messages match the repo's
+voice instead of generic conventional-commit boilerplate.
+"""
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+from noidea.git import Commit
+
+# How many recent commits to sample. Enough for stable ratios, recent enough to reflect
+# current conventions; a single fast git call with no API cost.
+SAMPLE_SIZE = 50
+
+# Below this many commits the ratios are dominated by single commits and mislead more
+# than they help, so we produce no profile and the caller keeps default behavior.
+MIN_COMMITS = 5
+
+# Keep only the most-used scopes so the prompt hint leads with the repo's dominant
+# vocabulary and stays compact on repos that have accumulated many one-off scopes.
+SCOPE_LIMIT_MAX = 8
+
+# A conventional-commit subject: type, optional (scope), optional !, then ": ".
+_CONVENTIONAL_RE = re.compile(r"^(\w+)(?:\(([^)]+)\))?!?: ")
+
+# A gitmoji prefix: either a :shortcode: or a leading emoji from the common emoji blocks
+# (misc symbols/dingbats U+2600-27BF, misc symbols-and-arrows U+2B00-2BFF, and the
+# supplementary emoji plane U+1F000-1FAFF that covers most gitmoji).
+_GITMOJI_RE = re.compile(r"^\s*(?::[a-z0-9_+-]+:|[☀-➿⬀-⯿\U0001f000-\U0001faff])")
+
+# A repo "uses gitmoji" only when the habit is dominant, not when one commit slipped one in.
+_GITMOJI_RATIO_MIN = 0.5
+
+# Above this share of conventional subjects we treat the repo as conventional and enforce
+# the format; below it we drop the type(scope): prefix to match the repo's plain style.
+CONVENTIONAL_THRESHOLD = 0.7
+
+# Body-habit bands: at/above HIGH the repo habitually writes bodies; at/below LOW it rarely
+# does; between, we state the observed share rather than push either way.
+_BODY_RATIO_HIGH = 0.5
+_BODY_RATIO_LOW = 0.15
+
+
+def _median_int(values: list[int]) -> int:
+    """Median of a non-empty list of ints, rounded to an int for even-length samples."""
+    assert values, "values must be non-empty"
+    ordered = sorted(values)
+    middle = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        result = ordered[middle]
+    else:
+        result = round((ordered[middle - 1] + ordered[middle]) / 2)
+    assert result >= 0, "median of non-negative lengths must be non-negative"
+    return result
+
+
+@dataclass(frozen=True)
+class StyleProfile:
+    """The repo's observed commit conventions, distilled from a sample of its log."""
+
+    scopes: tuple[str, ...]
+    conventional_ratio: float
+    body_ratio: float
+    subject_length_chars_median: int
+    uses_gitmoji: bool
+
+    def __post_init__(self):
+        assert isinstance(self.scopes, tuple), "scopes must be a tuple"
+        assert 0.0 <= self.conventional_ratio <= 1.0, "conventional_ratio must be in 0..1"
+        assert 0.0 <= self.body_ratio <= 1.0, "body_ratio must be in 0..1"
+        assert self.subject_length_chars_median >= 0, "median length must be non-negative"
+        assert isinstance(self.uses_gitmoji, bool), "uses_gitmoji must be a bool"
+
+
+def analyze_commits(commits: list[Commit]) -> StyleProfile | None:
+    """Distil a sample of commits into a StyleProfile, or None if there is too little signal."""
+    assert isinstance(commits, list), "commits must be a list"
+
+    if len(commits) < MIN_COMMITS:
+        return None
+
+    conventional_count = 0
+    body_count = 0
+    gitmoji_count = 0
+    scope_counts: Counter[str] = Counter()
+    subject_lengths: list[int] = []
+    for commit in commits:
+        subject_lengths.append(len(commit.subject))
+        if commit.body.strip():
+            body_count += 1
+        if _GITMOJI_RE.match(commit.subject):
+            gitmoji_count += 1
+        match = _CONVENTIONAL_RE.match(commit.subject)
+        if match:
+            conventional_count += 1
+            scope = match.group(2)
+            if scope:
+                scope_counts[scope] += 1
+
+    # most_common orders by count desc and breaks ties by first-seen, so the hint leads
+    # with the dominant scopes; cap keeps it compact on repos with many one-off scopes.
+    top_scopes = tuple(scope for scope, _ in scope_counts.most_common(SCOPE_LIMIT_MAX))
+    sample_size = len(commits)
+    profile = StyleProfile(
+        scopes=top_scopes,
+        conventional_ratio=conventional_count / sample_size,
+        body_ratio=body_count / sample_size,
+        subject_length_chars_median=_median_int(subject_lengths),
+        uses_gitmoji=gitmoji_count / sample_size >= _GITMOJI_RATIO_MIN,
+    )
+    assert isinstance(profile, StyleProfile), "analyze_commits must return a StyleProfile"
+    return profile
+
+
+def render_profile(profile: StyleProfile) -> str:
+    """Render the profile as a 'Repo commit conventions:' block for the prompt.
+
+    Applies the precedence rules: the quality floor stays in the system prompt; this block
+    only refines within it (additive scopes/gitmoji, tighten-only subject length) except for
+    the one honored contradiction — dropping the conventional prefix when the repo lacks it.
+    """
+    assert isinstance(profile, StyleProfile), "profile must be a StyleProfile"
+
+    lines: list[str] = ["Repo commit conventions:"]
+    if profile.conventional_ratio >= CONVENTIONAL_THRESHOLD:
+        if profile.scopes:
+            scope_list = ", ".join(profile.scopes)
+            lines.append(f"- this repo uses conventional commits; reuse its scopes: {scope_list}")
+        else:
+            lines.append("- this repo uses conventional commits; keep the type: prefix")
+    else:
+        lines.append(
+            "- this repo does not use conventional-commit prefixes; do not add a "
+            "type(scope): prefix, match its plain subject style"
+        )
+
+    # Tighten the subject target toward the repo's median, but never loosen past the 72-char
+    # quality floor the system prompt already enforces.
+    subject_target = min(72, profile.subject_length_chars_median)
+    lines.append(f"- aim for subjects around {subject_target} characters")
+
+    # Follow the repo's body habit. An extra body is never a quality regression, so this is
+    # allowed to loosen the default "only if non-obvious" rule when the repo writes bodies.
+    if profile.body_ratio >= _BODY_RATIO_HIGH:
+        lines.append("- most commits here include a short body; include one")
+    elif profile.body_ratio <= _BODY_RATIO_LOW:
+        lines.append("- commits here rarely include a body; usually omit it")
+    else:
+        body_percent = round(profile.body_ratio * 100)
+        lines.append(f"- about {body_percent}% of commits include a body; add one when it helps")
+
+    if profile.uses_gitmoji:
+        lines.append("- this repo prefixes subjects with a gitmoji; do the same")
+
+    rendered = "\n".join(lines)
+    assert rendered.startswith("Repo commit conventions:"), "render must produce the block header"
+    return rendered

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,41 @@
 [project]
 name = "noidea"
 version = "1.0.2"
-description = "You have no idea what to write? We've got you."
+description = "AI commit messages that pre-fill your git editor — Claude-powered, conventional-commits aware, learns your repo's style."
 authors = [
     {name = "AccursedGalaxy",email = "robinbohrer7@gmail.com"}
 ]
-license = {text = "MIT"}
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
+keywords = [
+    "git",
+    "commit",
+    "commit-message",
+    "commit-message-generator",
+    "conventional-commits",
+    "ai",
+    "llm",
+    "claude",
+    "anthropic",
+    "prepare-commit-msg",
+    "git-hooks",
+    "cli",
+    "developer-tools",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Version Control :: Git",
+    "Topic :: Utilities",
+]
 dependencies = [
     "anthropic (>=0.85.0,<1.0.0)",
     "python-dotenv (>=1.2.2,<2.0.0)",
@@ -18,6 +46,12 @@ dependencies = [
 
 [project.scripts]
 noidea = "noidea.cli:app"
+
+[project.urls]
+Homepage = "https://github.com/AccursedGalaxy/noidea"
+Repository = "https://github.com/AccursedGalaxy/noidea"
+Issues = "https://github.com/AccursedGalaxy/noidea/issues"
+Changelog = "https://github.com/AccursedGalaxy/noidea/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from typer.testing import CliRunner
 
 from noidea.cli import app
 from noidea.config import LlmConfig
-from noidea.git import DiffResult, HookResult
+from noidea.git import Commit, DiffResult, HookResult
 from noidea.key_store import KeyStoreError
 from noidea.provider import ErrorKind, ProviderError
 
@@ -26,6 +26,23 @@ class TestBuildUserContent:
 
         # The test command path: no git context, so the content is the diff alone.
         assert _build_user_content("+ added x", "", []) == "+ added x"
+
+    def test_includes_repo_conventions_when_profile_present(self):
+        from noidea.commands.suggest import _build_user_content
+
+        # When style learning produced guidance, it appears before the diff so the model
+        # reads the repo's conventions alongside the change.
+        result = _build_user_content(
+            "+ added x", "main", ["a.py"], "Repo commit conventions:\n- keep it terse"
+        )
+        assert "Repo commit conventions:\n- keep it terse" in result
+        assert result.index("Repo commit conventions:") < result.index("Diff:")
+
+    def test_omits_conventions_when_profile_absent(self):
+        from noidea.commands.suggest import _build_user_content
+
+        result = _build_user_content("+ added x", "main", ["a.py"], "")
+        assert "Repo commit conventions:" not in result
 
 
 class TestVersion:
@@ -108,6 +125,67 @@ class TestSuggest:
         result = runner.invoke(app, ["suggest", "--model", "claude-opus-4-7"])
         assert result.exit_code == 0
         assert mock_commit.call_args.args[2] == "claude-opus-4-7"
+
+    @patch("noidea.commands.suggest.complete", return_value="feat: thing")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch("noidea.commands.suggest.load_config", return_value=LlmConfig())
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ change"),
+    )
+    @patch(
+        "noidea.commands.suggest.get_recent_commits",
+        return_value=[Commit(f"feat(cli): change {i}", "") for i in range(6)],
+    )
+    def test_suggest_injects_learned_style_into_prompt(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # With style learning on and real history, the model sees the repo's conventions.
+        result = runner.invoke(app, ["suggest"])
+        assert result.exit_code == 0
+        user_content = mock_complete.call_args.args[1]
+        assert "Repo commit conventions:" in user_content
+        assert "cli" in user_content  # the repo's observed scope is surfaced
+
+    @patch("noidea.commands.suggest.complete", return_value="feat: thing")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch(
+        "noidea.commands.suggest.load_config",
+        return_value=LlmConfig(learn_commit_style=False),
+    )
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ change"),
+    )
+    @patch("noidea.commands.suggest.get_recent_commits")
+    def test_suggest_skips_style_learning_when_disabled(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # The kill-switch must avoid the git-log work entirely, not just drop the section.
+        result = runner.invoke(app, ["suggest"])
+        assert result.exit_code == 0
+        mock_log.assert_not_called()
+        assert "Repo commit conventions:" not in mock_complete.call_args.args[1]
+
+    @patch("noidea.commands.suggest.complete", return_value="feat: thing")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch("noidea.commands.suggest.load_config", return_value=LlmConfig())
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ change"),
+    )
+    @patch("noidea.commands.suggest.get_recent_commits", return_value=[])
+    def test_suggest_degrades_when_no_history(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # Thin/shallow history yields no profile; suggest still works, just without the section.
+        result = runner.invoke(app, ["suggest"])
+        assert result.exit_code == 0
+        assert "feat: thing" in result.output  # the mocked message still flows through
+        assert "Repo commit conventions:" not in mock_complete.call_args.args[1]
 
 
 class TestTestCommand:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,10 @@ class TestLlmConfig:
         assert cfg.max_tokens == 1024
         assert cfg.small_model == "claude-haiku-4-5"
 
+    def test_learn_commit_style_defaults_on(self):
+        # The differentiator ships on by default so every user gets repo-matched messages.
+        assert LlmConfig().learn_commit_style is True
+
     def test_from_dict_keeps_valid_value(self):
         cfg = LlmConfig.from_dict({"max_tokens": 512})
         assert cfg.max_tokens == 512
@@ -44,6 +48,17 @@ class TestLlmConfig:
         # bool is an int subclass but is never a valid numeric config value.
         cfg = LlmConfig.from_dict({"max_tokens": True})
         assert cfg.max_tokens == 1024
+
+    def test_from_dict_accepts_bool_for_learn_commit_style(self):
+        # The kill-switch is a real bool field, so an explicit false must be honored.
+        cfg = LlmConfig.from_dict({"learn_commit_style": False})
+        assert cfg.learn_commit_style is False
+
+    def test_from_dict_rejects_non_bool_learn_commit_style(self, capsys):
+        # A wrong-typed kill-switch falls back to the default with a warning, like any field.
+        cfg = LlmConfig.from_dict({"learn_commit_style": "yes"})
+        assert cfg.learn_commit_style is True
+        assert "Warning" in capsys.readouterr().err
 
     def test_select_model_small_below_limit(self):
         cfg = LlmConfig(context_limit=100)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,7 +1,48 @@
 import os
 from unittest.mock import MagicMock, patch
 
-from noidea.git import _strip_binary_hunks, get_diff, get_hooks_dir, install_hook
+from noidea.git import (
+    Commit,
+    _strip_binary_hunks,
+    get_diff,
+    get_hooks_dir,
+    get_recent_commits,
+    install_hook,
+)
+
+
+def test_get_recent_commits_parses_subjects_and_bodies():
+    """Recent commits are parsed into Commit objects with subject and body split out,
+    so the style analysis can read them without knowing the git log format."""
+    # Records terminated by 0x1e; subject and body separated by 0x1f (matches the format).
+    stdout = (
+        "feat(cli): add suggest\x1fwhy it was added\nmore detail\x1e"
+        "fix: handle empty diff\x1f\x1e"
+    )
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = stdout
+
+    with patch("noidea.git.subprocess.run", return_value=mock_result):
+        commits = get_recent_commits(50)
+
+    assert commits == [
+        Commit("feat(cli): add suggest", "why it was added\nmore detail"),
+        Commit("fix: handle empty diff", ""),
+    ]
+
+
+def test_get_recent_commits_degrades_to_empty_and_never_raises():
+    """Any failure (git error exit, or git not installed) yields an empty list rather
+    than raising, because the prepare-commit-msg hook aborts the commit on a crash."""
+    failed = MagicMock()
+    failed.returncode = 128
+    failed.stdout = ""
+    with patch("noidea.git.subprocess.run", return_value=failed):
+        assert get_recent_commits(50) == []
+
+    with patch("noidea.git.subprocess.run", side_effect=FileNotFoundError("git missing")):
+        assert get_recent_commits(50) == []
 
 
 def test_get_diff_nothing_staged():

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,5 +1,7 @@
 """Tests for repo-native commit style learning: analysis and rendering."""
 
+from dataclasses import replace
+
 from noidea.git import Commit
 from noidea.style import StyleProfile, analyze_commits, render_profile
 
@@ -102,17 +104,36 @@ def test_gitmoji_repo_is_recognized():
     assert plain_profile is not None and plain_profile.uses_gitmoji is False
 
 
+def test_gitmoji_prefix_does_not_hide_conventional_structure():
+    """A repo that uses gitmoji AND conventional commits is recognized as both: the
+    leading gitmoji must not stop the conventional type/scope from being detected."""
+    commits = [
+        Commit("✨ feat(cli): add suggest command", ""),
+        Commit("🐛 fix(provider): handle rate limits", ""),
+        Commit(":rocket: chore(release): cut 1.0.3", ""),
+        Commit("✨ feat(cli): add status output", ""),
+        Commit("♻️ refactor(config): collapse merge", ""),
+    ]
+
+    profile = analyze_commits(commits)
+
+    assert profile is not None
+    # The gitmoji prefix is stripped before the conventional check, so every subject counts.
+    assert profile.conventional_ratio == 1.0
+    assert profile.uses_gitmoji is True
+    assert set(profile.scopes) == {"cli", "provider", "release", "config"}
+
+
 def _profile(**overrides) -> StyleProfile:
     """A StyleProfile with sane defaults, overridable per render test."""
-    base = dict(
+    base = StyleProfile(
         scopes=(),
         conventional_ratio=1.0,
         body_ratio=0.0,
         subject_length_chars_median=50,
         uses_gitmoji=False,
     )
-    base.update(overrides)
-    return StyleProfile(**base)
+    return replace(base, **overrides)
 
 
 def test_render_conventional_repo_instructs_conventional_format_with_scopes():

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,0 +1,165 @@
+"""Tests for repo-native commit style learning: analysis and rendering."""
+
+from noidea.git import Commit
+from noidea.style import StyleProfile, analyze_commits, render_profile
+
+
+def test_conventional_repo_is_recognized_with_its_scopes():
+    """A repo whose history uses conventional commits is profiled as conventional,
+    and the scopes it actually uses are surfaced for reuse."""
+    commits = [
+        Commit("feat(cli): add suggest command", ""),
+        Commit("fix(provider): handle rate limits", ""),
+        Commit("refactor(config): collapse merge", ""),
+        Commit("feat(cli): add status output", ""),
+        Commit("docs(provider): document errors", ""),
+    ]
+
+    profile = analyze_commits(commits)
+
+    assert profile is not None
+    assert profile.conventional_ratio == 1.0
+    assert set(profile.scopes) == {"cli", "provider", "config"}
+
+
+def test_scopes_are_ranked_by_frequency_and_capped():
+    """Scopes are ordered most-used first and capped, so the prompt hint stays compact
+    and leads with the repo's dominant scopes rather than whatever appeared first."""
+    # cli x4, provider x2, then nine distinct one-off scopes.
+    commits = (
+        [Commit(f"feat(cli): change {i}", "") for i in range(4)]
+        + [Commit(f"fix(provider): change {i}", "") for i in range(2)]
+        + [Commit(f"chore(scope{i}): change", "") for i in range(9)]
+    )
+
+    profile = analyze_commits(commits)
+
+    assert profile is not None
+    # Most frequent first; ties (the one-offs) keep first-seen order.
+    assert profile.scopes[:2] == ("cli", "provider")
+    # Capped to the top 8 even though 11 distinct scopes were seen.
+    assert len(profile.scopes) == 8
+
+
+def test_too_few_commits_yields_no_profile():
+    """Below the minimum sample, ratios are meaningless, so no profile is produced
+    and callers fall back to default behavior."""
+    commits = [Commit(f"feat: change {i}", "") for i in range(4)]
+
+    assert analyze_commits(commits) is None
+
+
+def test_body_ratio_reflects_how_often_commits_have_bodies():
+    """A repo where most commits carry an explanatory body is profiled as body-writing."""
+    commits = [
+        Commit("feat: a", "why a happened"),
+        Commit("feat: b", "why b happened"),
+        Commit("feat: c", "why c happened"),
+        Commit("fix: d", ""),
+        Commit("fix: e", ""),
+    ]
+
+    profile = analyze_commits(commits)
+
+    assert profile is not None
+    assert profile.body_ratio == 0.6
+
+
+def test_subject_length_is_the_median_of_observed_subjects():
+    """The profile captures the repo's typical subject length via the median, so a
+    single very long or short subject does not skew it."""
+    # Subject lengths: 10, 20, 30, 40, 200 -> median is 30.
+    commits = [
+        Commit("a" * 10, ""),
+        Commit("b" * 20, ""),
+        Commit("c" * 30, ""),
+        Commit("d" * 40, ""),
+        Commit("e" * 200, ""),
+    ]
+
+    profile = analyze_commits(commits)
+
+    assert profile is not None
+    assert profile.subject_length_chars_median == 30
+
+
+def test_gitmoji_repo_is_recognized():
+    """A repo that prefixes subjects with gitmoji (emoji or :shortcode:) is profiled
+    as using gitmoji; a plain repo is not."""
+    gitmoji_commits = [
+        Commit("✨ feat: add suggest", ""),
+        Commit("🐛 fix: handle empty diff", ""),
+        Commit(":rocket: chore: release", ""),
+        Commit("✨ feat: add status", ""),
+        Commit("refactor: tidy imports", ""),
+    ]
+    plain_commits = [Commit(f"feat: change {i}", "") for i in range(5)]
+
+    gitmoji_profile = analyze_commits(gitmoji_commits)
+    plain_profile = analyze_commits(plain_commits)
+
+    assert gitmoji_profile is not None and gitmoji_profile.uses_gitmoji is True
+    assert plain_profile is not None and plain_profile.uses_gitmoji is False
+
+
+def _profile(**overrides) -> StyleProfile:
+    """A StyleProfile with sane defaults, overridable per render test."""
+    base = dict(
+        scopes=(),
+        conventional_ratio=1.0,
+        body_ratio=0.0,
+        subject_length_chars_median=50,
+        uses_gitmoji=False,
+    )
+    base.update(overrides)
+    return StyleProfile(**base)
+
+
+def test_render_conventional_repo_instructs_conventional_format_with_scopes():
+    """When the repo uses conventional commits, the rendered guidance keeps the format
+    and surfaces the repo's own scope vocabulary for reuse."""
+    profile = _profile(conventional_ratio=1.0, scopes=("cli", "provider"))
+
+    rendered = render_profile(profile)
+
+    assert "conventional" in rendered.lower()
+    assert "cli" in rendered and "provider" in rendered
+
+
+def test_render_non_conventional_repo_drops_the_prefix():
+    """When the repo plainly does not use conventional commits, the guidance tells the
+    model to match that — no type(scope): prefix — rather than impose the format."""
+    profile = _profile(conventional_ratio=0.1, scopes=())
+
+    rendered = render_profile(profile).lower()
+
+    assert "not" in rendered and "prefix" in rendered
+
+
+def test_render_subject_length_tightens_but_never_loosens():
+    """A repo with short subjects pulls the target down; a repo with long subjects is
+    still capped at the 72-char quality floor."""
+    short = render_profile(_profile(subject_length_chars_median=45))
+    long = render_profile(_profile(subject_length_chars_median=90))
+
+    assert "45" in short
+    assert "90" not in long and "72" in long
+
+
+def test_render_body_habit_follows_the_repo():
+    """A repo that usually writes bodies is told to include one; a repo that rarely does
+    is told to usually omit it."""
+    body_heavy = render_profile(_profile(body_ratio=0.8)).lower()
+    body_light = render_profile(_profile(body_ratio=0.05)).lower()
+
+    assert "body" in body_heavy and "include" in body_heavy
+    assert "body" in body_light and ("omit" in body_light or "rarely" in body_light)
+
+
+def test_render_mentions_gitmoji_only_when_the_repo_uses_it():
+    """A gitmoji repo is told to prefix with a gitmoji; a plain repo gets no such line."""
+    with_gitmoji = render_profile(_profile(uses_gitmoji=True)).lower()
+    without_gitmoji = render_profile(_profile(uses_gitmoji=False)).lower()
+
+    assert "gitmoji" in with_gitmoji or "emoji" in with_gitmoji
+    assert "gitmoji" not in without_gitmoji and "emoji" not in without_gitmoji


### PR DESCRIPTION
## What & why

Two threads of work from a competitive/SEO analysis of the AI-commit-tool space:

1. **Repo-native style learning** (the headline differentiator). Before generating, noidea now samples the last 50 non-merge commits, distils them into a `StyleProfile` (scope vocabulary, body habit, median subject length, gitmoji usage), and injects that guidance into the prompt — so suggestions read like *this* project's commits instead of generic conventional-commit boilerplate. No competing tool (aicommits, opencommit, aicommit2, gptcommit, czg) learns a repo's voice; they emit a static template.

2. **PyPI discoverability metadata**. The package name carries no category keywords and PyPI was rendering a keyword-free summary, leaving the project invisible to anyone searching for an "ai commit message" tool. Added a keyword-rich description, keywords, trove classifiers, and `[project.urls]`.

## Design (style learning)

- **Precedence:** the quality floor stays in the system prompt; the profile only *refines* within it — additive scopes/gitmoji, subject length tightens-only (`min(72, median)`), body habit may loosen. The one honored contradiction is dropping the conventional prefix when the repo demonstrably doesn't use it.
- **Hook-safe:** `get_recent_commits` degrades to `[]` on any git failure and `analyze_commits` returns `None` below 5 commits — because `prepare-commit-msg` aborts the commit on a non-zero exit. Thin/shallow history falls back to today's behavior.
- **On by default** with a single kill-switch (`learn_commit_style: false`); scopes are frequency-ranked and capped at 8.

Full design rationale in `docs/style-learning-plan.md`; competitor/SEO analysis in `docs/competitive-analysis.md`.

## Incidental fix

Adding the first real `bool` config field exposed that `_matches_default_type` rejected *every* bool value (it was written when bool was only ever an invalid numeric sneak-in). Fixed so a bool default accepts bool while numeric/str fields still reject it — otherwise `learn_commit_style: false` would have been silently flipped back to `true`.

## Testing

- **+20 tests** (118 total, all green) across `test_style.py`, `test_git.py`, `test_config.py`, `test_cli.py`. Built via TDD red-green-refactor, vertical slices.
- black / isort / pyright clean; `poetry check` clean (license modernized to SPDX `MIT`).
- Verified the pipeline on this repo's real history (no API call): `conventional_ratio 0.96`, real scopes surfaced, body habit and median length correct.

## Note for reviewers

The noidea hook clobbers an explicitly-provided commit message (`-F`/`-m`) instead of only filling an empty one — it overwrote the first commit on this branch. Worth a follow-up: skip generation when the message file is already non-empty (how gptcommit behaves). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic commit style learning: the tool now samples recent repository history to understand and match your team's commit conventions and voice (enabled by default).

* **Documentation**
  * Updated README with `learn_commit_style` configuration option.
  * Enhanced project metadata with keywords and discovery links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AccursedGalaxy/noidea/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->