### PR TITLE
feat(suggest): surface cost-aware routing + Why noidea? pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Stages your diff, sends it to an AI, and pre-fills your commit editor — so you
 
 ---
 
+## Why noidea?
+
+There are plenty of AI commit tools. noidea is the one that fits the way you already work:
+
+- **Writes in your repo's voice, not generic AI boilerplate.** Before generating, noidea reads how your repo already commits — its scope vocabulary, body habits, subject length, gitmoji or not — and matches it. Your history stays consistent instead of looking like a bot dropped in.
+- **Spends pennies and milliseconds on trivial commits.** Small diffs go to a fast, cheap model; only substantial changes escalate to the strong one — automatically, and it tells you which it chose. No paying premium rates to commit a typo fix.
+- **Never auto-commits — you always get the last word.** It pre-fills your editor on `git commit`. No new command to remember, no message committed behind your back. Edit or delete it like any draft.
+- **Terminal-native and private by design.** A small, MIT-licensed Python CLI built to a strict [safety-first style guide](STYLE.md). Your diffs go straight to your chosen model and nowhere else.
+
 ## Quick Start
 
 ```bash

--- a/noidea/commands/suggest.py
+++ b/noidea/commands/suggest.py
@@ -59,6 +59,23 @@ def _learn_style(cfg: LlmConfig) -> str:
     return profile_text
 
 
+def _print_routing_notice(cfg: LlmConfig, selected_model: str) -> None:
+    """Surface the cost-aware routing decision so its value is felt, not buried in config.
+
+    Printed to stderr (the message itself goes to stdout / the hook file), so it never
+    pollutes what the hook consumes. The caller skips it when --model forces a single
+    model, since then there is no routing decision to report.
+    """
+    assert isinstance(cfg, LlmConfig), "cfg must be an LlmConfig"
+    assert isinstance(selected_model, str) and selected_model, "selected_model must be non-empty"
+    if selected_model == cfg.small_model:
+        console.print(f"[dim]Small diff → {selected_model} · fast & cheap[/dim]")
+    else:
+        console.print(
+            f"[dim]Large change → escalating to {selected_model} · the strong model[/dim]"
+        )
+
+
 def _generate_message(
     diff, cfg: LlmConfig, model, branch, staged_files, profile_text
 ) -> str | None:
@@ -111,6 +128,9 @@ def suggest(
     context_length_chars = len(cfg.system_prompt) + len(diff.diff)
 
     selected_model = cfg.select_model(context_length_chars)
+    # Show the routing decision, except when --model forced a single model (no decision made).
+    if not model:
+        _print_routing_notice(cfg, selected_model)
 
     commit_message = _generate_message(
         diff.diff, cfg, selected_model, branch, staged_files, profile_text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,6 +187,63 @@ class TestSuggest:
         assert "feat: thing" in result.output  # the mocked message still flows through
         assert "Repo commit conventions:" not in mock_complete.call_args.args[1]
 
+    @patch("noidea.commands.suggest.complete", return_value="fix: x")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch("noidea.commands.suggest.load_config", return_value=LlmConfig())
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ tiny"),
+    )
+    @patch("noidea.commands.suggest.get_recent_commits", return_value=[])
+    def test_suggest_announces_small_model_routing(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # A tiny diff stays on the fast/cheap model, and the routing is made visible.
+        result = runner.invoke(app, ["suggest"])
+        assert result.exit_code == 0
+        assert "Small diff" in result.output
+        assert "claude-haiku-4-5" in result.output
+
+    @patch("noidea.commands.suggest.complete", return_value="feat: big")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch(
+        "noidea.commands.suggest.load_config",
+        return_value=LlmConfig(context_limit=1.0),
+    )
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ a substantial change"),
+    )
+    @patch("noidea.commands.suggest.get_recent_commits", return_value=[])
+    def test_suggest_announces_escalation_routing(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # A diff over the threshold escalates to the strong model, and that is announced.
+        result = runner.invoke(app, ["suggest"])
+        assert result.exit_code == 0
+        assert "escalating" in result.output
+        assert "claude-sonnet-4-6" in result.output
+
+    @patch("noidea.commands.suggest.complete", return_value="fix: thing")
+    @patch("noidea.commands.suggest.get_branch_name", return_value="main")
+    @patch("noidea.commands.suggest.get_staged_files", return_value=["a.py"])
+    @patch("noidea.commands.suggest.load_config", return_value=LlmConfig())
+    @patch(
+        "noidea.commands.suggest.get_diff",
+        return_value=DiffResult(has_changes=True, diff="+ change"),
+    )
+    @patch("noidea.commands.suggest.get_recent_commits", return_value=[])
+    def test_suggest_suppresses_routing_notice_when_model_forced(
+        self, mock_log, mock_diff, mock_config, mock_staged, mock_branch, mock_complete
+    ):
+        # --model forces a single model, so there is no routing decision to report.
+        result = runner.invoke(app, ["suggest", "--model", "claude-opus-4-7"])
+        assert result.exit_code == 0
+        assert "Small diff" not in result.output
+        assert "escalating" not in result.output
+
 
 class TestTestCommand:
     @patch("noidea.commands.test.complete", return_value="hello!")


### PR DESCRIPTION
## What

Promotes noidea's two real differentiators from buried/silent to felt and quotable — the conversion half of the discoverability plan.

- **Cost-aware routing is now visible.** `suggest` prints which model tier it chose and why:
  - `Small diff → claude-haiku-4-5 · fast & cheap`
  - `Large change → escalating to claude-sonnet-4-6 · the strong model`

  Printed to **stderr**, so the `prepare-commit-msg` hook still consumes only the message from stdout/file. Suppressed when `--model` forces a single model (no routing decision to report).
- **README "Why noidea?" section** leading with the four differentiators (repo-native voice, cost-aware routing, never auto-commits, terminal-native/private) in the 8-second conversion window.

## Why

The analysis docs flagged that features alone don't convert stars (aicommit2 out-features the field at ~500 stars). The cost-aware routing was genuinely unique but invisible — silent in code, hidden in config docs. This makes the value felt at commit time and quotable for a listicle.

## Tests

- 3 new tests cover the routing notice: small-model announcement, escalation announcement, and suppression under `--model`.
- Full suite: **122 passed**, black/isort/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)