### PR TITLE
feat(provider): multi-provider support (Anthropic / OpenAI / Ollama / Gemini / DeepSeek / Groq)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Set `provider` in your config (see [Config](#config)) to route every request to 
 
 Set `base_url` to override the endpoint — e.g. point `openai` at a self-hosted vLLM server. Remember to also set `small_model`/`large_model` to models the provider actually serves (e.g. `"small_model": "llama3.2"` for Ollama).
 
+> **Note:** the OpenAI-compatible path sends `max_tokens`, so it targets standard chat models (e.g. `gpt-4o`, `llama3.2`). OpenAI's reasoning models (the `o1`/`o3`/`gpt-5` family) reject `max_tokens` in favour of `max_completion_tokens` and are not yet supported — pick a chat model for `small_model`/`large_model`.
+
 ## Commands
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -39,15 +39,40 @@ That's it. Every `git commit` now opens your editor with a suggested message pre
 
 > Requires [pipx](https://pipx.pypa.io). Alternatively: `pip install noidea`
 
+Works with **Claude, GPT, and local Ollama models** (plus Gemini, DeepSeek, Groq) — switching is a one-line config change, see [Multi-provider](#multi-provider). Want to try it with zero setup and no API key? Point it at a local Ollama model.
+
 ## API Key Setup
 
-noidea needs an Anthropic API key. Three options (checked in order):
+By default noidea uses Anthropic (Claude). The key is looked up in three places, in order:
 
 | Method | Command |
 |--------|---------|
 | **Keyring** (recommended) | `noidea keys add` |
 | **Environment variable** | `export ANTHROPIC_API_KEY=sk-ant-...` |
 | **`.env` file** | `ANTHROPIC_API_KEY=sk-ant-...` in a `.env` file |
+
+Other providers follow the same pattern with their own env var (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`) or `noidea keys add <provider>`.
+
+**Ollama needs no key.** It runs locally, so once `provider` is set to `ollama` (below) you can generate commit messages with nothing else configured.
+
+### Multi-provider
+
+Set `provider` in your config (see [Config](#config)) to route every request to a different backend — no code change, no extra install:
+
+```json
+{ "llm": { "provider": "ollama" } }
+```
+
+| `provider` | Needs a key? | Default endpoint |
+|------------|--------------|------------------|
+| `anthropic` (default) | yes | Anthropic SDK default |
+| `openai` | yes | OpenAI SDK default |
+| `ollama` | **no** | `http://localhost:11434/v1` |
+| `gemini` | yes | Google's OpenAI-compatible endpoint |
+| `deepseek` | yes | `https://api.deepseek.com` |
+| `groq` | yes | `https://api.groq.com/openai/v1` |
+
+Set `base_url` to override the endpoint — e.g. point `openai` at a self-hosted vLLM server. Remember to also set `small_model`/`large_model` to models the provider actually serves (e.g. `"small_model": "llama3.2"` for Ollama).
 
 ## Commands
 
@@ -86,6 +111,8 @@ Precedence: built-in defaults → user config → repo config.
     "context_limit": 600000,
     "temperature": 1.0,
     "learn_commit_style": true,
+    "provider": "anthropic",
+    "base_url": "",
     "system_prompt": "Your custom prompt here"
   }
 }
@@ -104,4 +131,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines. Thi
 ## Requirements
 
 - Python 3.10+
-- Anthropic API key
+- An LLM provider: an Anthropic, OpenAI, Gemini, DeepSeek, or Groq API key — or a local [Ollama](https://ollama.com) install (no key needed)

--- a/noidea/commands/keys.py
+++ b/noidea/commands/keys.py
@@ -21,7 +21,7 @@ def show():
 
 @keys_app.command()
 def add(provider: Provider = typer.Argument(default=Provider.ANTHROPIC)):
-    """Stash an API key in your keyring."""
+    """Stash an API key in your keyring. Ollama is local and needs no key — skip this for it."""
     try:
         key = typer.prompt("Enter your key:", hide_input=True)
         if key_store.add(provider.value, key):

--- a/noidea/commands/suggest.py
+++ b/noidea/commands/suggest.py
@@ -92,6 +92,8 @@ def _generate_message(
                 model,
                 cfg.max_tokens,
                 cfg.temperature,
+                provider=cfg.provider,
+                base_url=cfg.base_url,
             )
     except ProviderError as error:
         print(SUGGEST_WORDING[error.kind](error))

--- a/noidea/commands/test.py
+++ b/noidea/commands/test.py
@@ -49,6 +49,8 @@ def test():
                 f"tell a creative short coding joke about {topic}",
                 cfg.large_model,
                 cfg.max_tokens,
+                provider=cfg.provider,
+                base_url=cfg.base_url,
             )
     except ProviderError as error:
         print(TEST_WORDING[error.kind](error))

--- a/noidea/config.py
+++ b/noidea/config.py
@@ -31,6 +31,11 @@ _DEFAULT_SYSTEM_PROMPT = (
 
 class Provider(str, Enum):
     ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    OLLAMA = "ollama"
+    GEMINI = "gemini"
+    DEEPSEEK = "deepseek"
+    GROQ = "groq"
 
 
 @dataclass(frozen=True)
@@ -49,6 +54,8 @@ class LlmConfig:
     system_prompt: str = _DEFAULT_SYSTEM_PROMPT
     temperature: float = 1.0
     learn_commit_style: bool = True  # Match the repo's observed commit conventions.
+    provider: str = "anthropic"  # Which backend complete() dispatches to; see provider.py.
+    base_url: str = ""  # Overrides the per-provider default endpoint (e.g. a custom vLLM host).
 
     def __post_init__(self):
         # The pair to from_dict's pre-construction type check: assert the invariants
@@ -62,6 +69,8 @@ class LlmConfig:
         assert isinstance(self.temperature, (int, float))
         assert not isinstance(self.temperature, bool)
         assert isinstance(self.learn_commit_style, bool)
+        assert isinstance(self.provider, str)
+        assert isinstance(self.base_url, str)
 
     @classmethod
     def from_dict(cls, data: dict) -> "LlmConfig":
@@ -85,6 +94,16 @@ class LlmConfig:
                     file=sys.stderr,
                 )
                 values[spec.name] = default
+        # A type-valid but unknown provider (a hand-edited typo) is coerced back to the default
+        # here, so it warns now rather than crashing later inside complete() with a raw ValueError.
+        known_providers = {member.value for member in Provider}
+        if values["provider"] not in known_providers:
+            print(
+                f"Warning: llm.provider {values['provider']!r} is not a known provider,"
+                " using default.",
+                file=sys.stderr,
+            )
+            values["provider"] = defaults.provider
         result = cls(**values)
         assert isinstance(result, LlmConfig), "from_dict must return an LlmConfig"
         return result

--- a/noidea/key_store.py
+++ b/noidea/key_store.py
@@ -25,7 +25,15 @@ load_dotenv()
 KEYS_FILENAME = "keys.json"
 KEYS_PATH = os.path.join(CONFIG_DIR, KEYS_FILENAME)
 
-ANTHROPIC_ENV_VAR = "ANTHROPIC_API_KEY"
+# The env var each provider's key falls back to, for CI/headless use. Ollama is absent on
+# purpose: it needs no key, so it never reads one. This table is the only provider→env-var map.
+_PROVIDER_ENV_VARS = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "groq": "GROQ_API_KEY",
+}
 
 
 class KeyStoreError(Exception):
@@ -100,11 +108,14 @@ class KeyStore:
         return names
 
     def get(self, provider: str) -> str | None:
-        """Return the secret from the keyring, falling back to the env var for Anthropic."""
+        """Return the keyring secret, falling back to the provider's env var if it has one."""
         assert isinstance(provider, str) and provider, "provider must be a non-empty string"
         secret = self._read_secret(provider)
-        if not secret and provider == "anthropic":
-            secret = os.environ.get(ANTHROPIC_ENV_VAR)
+        if not secret:
+            # No keyless provider (e.g. ollama) is in the table, so it never reads an env var.
+            env_var = _PROVIDER_ENV_VARS.get(provider)
+            if env_var:
+                secret = os.environ.get(env_var)
         assert secret is None or isinstance(secret, str), "secret must be a string or None"
         return secret
 

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -144,14 +144,11 @@ def _complete_openai_compat(
     """Shared transport for the OpenAI-compatible providers; one error ladder serves all of them."""
     assert provider in _OPENAI_COMPAT, "provider must be an OpenAI-compatible provider"
     assert isinstance(base_url, str), "base_url must be a string"
-    try:
-        import openai
-        from openai import OpenAI
-    except ImportError as error:
-        raise ProviderError(
-            ErrorKind.STATUS,
-            "The 'openai' package is required for this provider. Run 'pip install openai'.",
-        ) from error
+    # openai is a core dependency, imported lazily so the Anthropic default path never pays
+    # its import cost. A missing openai is an install fault, not a runtime error to handle.
+    import openai
+    from openai import OpenAI
+
     # base_url precedence: explicit config > per-provider default > the SDK's own default (None).
     resolved_base_url = base_url or _DEFAULT_BASE_URLS.get(provider, "")
     api_key = "ollama" if provider in _NO_KEY_PROVIDERS else get_api_key(provider)

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -1,4 +1,11 @@
-"""Anthropic completion transport: one deep call that owns the API and its error taxonomy."""
+"""LLM completion transport: one public complete() over two backends, one error taxonomy.
+
+Anthropic has a distinct message shape and SDK, so it gets its own transport. Every other
+supported provider (OpenAI, Ollama, Gemini, DeepSeek, Groq) speaks OpenAI's chat-completions
+format, so they share a single transport — one path unlocks five providers. Both transports
+collapse their SDK's exception hierarchy into one ProviderError here, so callers handle a single
+error type and never import a provider SDK.
+"""
 
 from enum import Enum
 
@@ -6,12 +13,11 @@ import anthropic
 from anthropic import Anthropic
 from anthropic.types import TextBlock
 
-from noidea.config import Provider
 from noidea.key_store import key_store
 
 
 class ErrorKind(Enum):
-    """The category of a transport failure, so callers can word it without knowing anthropic."""
+    """The category of a transport failure, so callers can word it without knowing the SDK."""
 
     AUTH = "auth"  # The API key was rejected.
     RATE_LIMIT = "rate_limit"  # Too many requests; back off and retry.
@@ -20,7 +26,7 @@ class ErrorKind(Enum):
 
 
 class ProviderError(Exception):
-    """The single failure type callers handle; anthropic's hierarchy never leaks past complete()."""
+    """The single failure type callers handle; an SDK's hierarchy never leaks past complete()."""
 
     def __init__(self, kind: ErrorKind, message: str, status_code: int | None = None):
         assert isinstance(kind, ErrorKind), "kind must be an ErrorKind"
@@ -31,11 +37,30 @@ class ProviderError(Exception):
         self.status_code = status_code
 
 
-def get_api_key(provider: Provider = Provider.ANTHROPIC) -> str:
-    # key_store consults the keyring first, then the ANTHROPIC_API_KEY env var for CI/headless.
-    key = key_store.get(provider.value)
+# Providers that speak OpenAI's chat-completions format, served by the one shared transport.
+_OPENAI_COMPAT = {"openai", "ollama", "gemini", "deepseek", "groq"}
+
+# The default endpoint per OpenAI-compat provider; config base_url overrides any of these.
+# OpenAI itself has no entry, so it falls through to the SDK's own default base URL.
+_DEFAULT_BASE_URLS = {
+    "ollama": "http://localhost:11434/v1",
+    "gemini": "https://generativelanguage.googleapis.com/v1beta/openai/",
+    # DeepSeek's base intentionally has no /v1 suffix: its API also serves the OpenAI path here.
+    "deepseek": "https://api.deepseek.com",
+    "groq": "https://api.groq.com/openai/v1",
+}
+
+# Providers that need no API key (local, keyless). The OpenAI SDK still wants a non-empty key
+# string, so we pass a harmless placeholder that the local backend ignores.
+_NO_KEY_PROVIDERS = {"ollama"}
+
+
+def get_api_key(provider: str = "anthropic") -> str:
+    # key_store consults the keyring first, then the provider's *_API_KEY env var for CI/headless.
+    assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+    key = key_store.get(provider)
     if not key:
-        raise SystemExit("No API key found. Run 'noidea keys add'.")
+        raise SystemExit(f"No API key found for {provider}. Run 'noidea keys add'.")
     assert isinstance(key, str) and key, "api key must be a non-empty string"
     return key
 
@@ -46,6 +71,9 @@ def complete(
     model: str,
     max_tokens: int,
     temperature: float = 1.0,
+    *,
+    provider: str = "anthropic",
+    base_url: str = "",
 ) -> str:
     # Validate inputs at the API boundary before spending a network round-trip.
     if not isinstance(system, str) or not system.strip():
@@ -58,10 +86,27 @@ def complete(
         raise TypeError(f"max_tokens must be a positive integer, got {type(max_tokens).__name__}")
     if not isinstance(temperature, (int, float)) or temperature < 0:
         raise TypeError(f"temperature must be a non-negative number, got {temperature!r}")
+    assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+    assert isinstance(base_url, str), "base_url must be a string"
 
+    # Dispatch on provider: Anthropic's own transport, else the shared OpenAI-compat one.
+    if provider == "anthropic":
+        return _complete_anthropic(system, user, model, max_tokens, temperature)
+    if provider in _OPENAI_COMPAT:
+        return _complete_openai_compat(
+            system, user, model, max_tokens, temperature, provider, base_url
+        )
+    raise ValueError(f"unknown provider: {provider!r}")
+
+
+def _complete_anthropic(
+    system: str, user: str, model: str, max_tokens: int, temperature: float
+) -> str:
+    """Anthropic transport: build a client, translate its errors to one ProviderError."""
+    assert isinstance(model, str) and model, "model must be a non-empty string"
+    assert isinstance(max_tokens, int) and max_tokens > 0, "max_tokens must be a positive int"
     client = Anthropic(api_key=get_api_key())
-    # Translate anthropic's exception hierarchy into one ProviderError here, so no caller
-    # ever imports anthropic. Specific kinds first; APIError is the catch-all base last.
+    # Specific kinds first; APIError is the catch-all base last.
     try:
         message = client.messages.create(
             model=model,
@@ -85,3 +130,54 @@ def complete(
     if not isinstance(block, TextBlock):
         raise TypeError(f"Expected TextBlock, got {type(block).__name__}")
     return block.text
+
+
+def _complete_openai_compat(
+    system: str,
+    user: str,
+    model: str,
+    max_tokens: int,
+    temperature: float,
+    provider: str,
+    base_url: str,
+) -> str:
+    """Shared transport for the OpenAI-compatible providers; one error ladder serves all of them."""
+    assert provider in _OPENAI_COMPAT, "provider must be an OpenAI-compatible provider"
+    assert isinstance(base_url, str), "base_url must be a string"
+    try:
+        import openai
+        from openai import OpenAI
+    except ImportError as error:
+        raise ProviderError(
+            ErrorKind.STATUS,
+            "The 'openai' package is required for this provider. Run 'pip install openai'.",
+        ) from error
+    # base_url precedence: explicit config > per-provider default > the SDK's own default (None).
+    resolved_base_url = base_url or _DEFAULT_BASE_URLS.get(provider, "")
+    api_key = "ollama" if provider in _NO_KEY_PROVIDERS else get_api_key(provider)
+    client = OpenAI(api_key=api_key, base_url=resolved_base_url or None)
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    except openai.AuthenticationError as error:
+        raise ProviderError(ErrorKind.AUTH, str(error)) from error
+    except openai.RateLimitError as error:
+        raise ProviderError(ErrorKind.RATE_LIMIT, str(error)) from error
+    except openai.APIConnectionError as error:
+        raise ProviderError(ErrorKind.CONNECTION, str(error)) from error
+    except openai.APIStatusError as error:
+        raise ProviderError(ErrorKind.STATUS, str(error), error.status_code) from error
+    except openai.OpenAIError as error:
+        raise ProviderError(ErrorKind.STATUS, str(error)) from error
+    content = response.choices[0].message.content
+    # A compat backend can return None or a non-string when no text was produced.
+    if not isinstance(content, str) or not content:
+        raise TypeError(f"Expected a text completion, got {type(content).__name__}")
+    return content

--- a/poetry.lock
+++ b/poetry.lock
@@ -821,6 +821,34 @@ files = [
 ]
 
 [[package]]
+name = "openai"
+version = "1.109.1"
+description = "The official Python library for the openai API"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "openai-1.109.1-py3-none-any.whl", hash = "sha256:6bcaf57086cf59159b8e27447e4e7dd019db5d29a438072fbd49c290c7e65315"},
+    {file = "openai-1.109.1.tar.gz", hash = "sha256:d173ed8dbca665892a6db099b4a2dfac624f94d20a93f46eb0b56aae940ed869"},
+]
+
+[package.dependencies]
+anyio = ">=3.5.0,<5"
+distro = ">=1.7.0,<2"
+httpx = ">=0.23.0,<1"
+jiter = ">=0.4.0,<1"
+pydantic = ">=1.9.0,<3"
+sniffio = "*"
+tqdm = ">4"
+typing-extensions = ">=4.11,<5"
+
+[package.extras]
+aiohttp = ["aiohttp", "httpx-aiohttp (>=0.1.8)"]
+datalib = ["numpy (>=1)", "pandas (>=1.2.3)", "pandas-stubs (>=1.1.0.11)"]
+realtime = ["websockets (>=13,<16)"]
+voice-helpers = ["numpy (>=2.0.2)", "sounddevice (>=0.5.1)"]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 description = "Core utilities for Python packages"
@@ -1309,6 +1337,28 @@ files = [
 ]
 
 [[package]]
+name = "tqdm"
+version = "4.67.3"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"},
+    {file = "tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
 name = "typer"
 version = "0.24.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
@@ -1377,4 +1427,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "1682d22863a48caf94c146f35e06fff7a6b8b6480b30d24f0d3f0212b34ad4a3"
+content-hash = "2e63bdb690edd19d7fb1374898d340928ef65dba15aabe0c7011c30a4d68ac33"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "typer (>=0.24.1,<1.0.0)",
     "keyring (>=25.7.0,<26.0.0)",
     "rich (>=13.0.0)",
+    "openai (>=1.0.0,<2.0.0)",
 ]
 
 [project.scripts]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,6 +19,33 @@ class TestLlmConfig:
         # The differentiator ships on by default so every user gets repo-matched messages.
         assert LlmConfig().learn_commit_style is True
 
+    def test_provider_defaults_to_anthropic(self):
+        # Backward compatible: an unconfigured install keeps talking to Anthropic.
+        cfg = LlmConfig()
+        assert cfg.provider == "anthropic"
+        assert cfg.base_url == ""
+
+    def test_from_dict_picks_up_provider_and_base_url(self):
+        cfg = LlmConfig.from_dict({"provider": "ollama", "base_url": "http://host:11434/v1"})
+        assert cfg.provider == "ollama"
+        assert cfg.base_url == "http://host:11434/v1"
+
+    def test_from_dict_rejects_non_str_provider(self, capsys):
+        cfg = LlmConfig.from_dict({"provider": 123})
+        assert cfg.provider == "anthropic"
+        assert "Warning" in capsys.readouterr().err
+
+    def test_from_dict_rejects_unknown_provider(self, capsys):
+        # A hand-edited typo must be coerced back to the default and warned, not carried
+        # forward to crash later inside complete() with an uncaught ValueError.
+        cfg = LlmConfig.from_dict({"provider": "claude"})
+        assert cfg.provider == "anthropic"
+        assert "Warning" in capsys.readouterr().err
+
+    def test_from_dict_accepts_every_known_provider(self):
+        for name in ("anthropic", "openai", "ollama", "gemini", "deepseek", "groq"):
+            assert LlmConfig.from_dict({"provider": name}).provider == name
+
     def test_from_dict_keeps_valid_value(self):
         cfg = LlmConfig.from_dict({"max_tokens": 512})
         assert cfg.max_tokens == 512

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -37,6 +37,28 @@ class TestAddAndGet:
         store = _make_store(tmp_path)
         assert store.get("anthropic") == "env-key-456"
 
+    def test_get_falls_back_to_env_var_for_openai(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-789")
+        store = _make_store(tmp_path)
+        assert store.get("openai") == "sk-openai-789"
+
+    def test_get_falls_back_to_env_var_for_groq(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-groq-1")
+        store = _make_store(tmp_path)
+        assert store.get("groq") == "gsk-groq-1"
+
+    def test_get_returns_none_for_keyless_ollama(self, tmp_path, monkeypatch):
+        # Ollama needs no key, so it has no env var and never reads one.
+        monkeypatch.setenv("OLLAMA_API_KEY", "should-be-ignored")
+        store = _make_store(tmp_path)
+        assert store.get("ollama") is None
+
+    def test_keyring_secret_wins_over_env_var(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "env-loses")
+        store = _make_store(tmp_path)
+        store.add("openai", "keyring-wins")
+        assert store.get("openai") == "keyring-wins"
+
 
 class TestList:
     def test_list_is_empty_for_fresh_store(self, tmp_path):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -208,6 +208,42 @@ class TestCompleteDispatch:
             complete("s", "u", "m", 10, provider="not-a-provider")
 
 
+class TestProviderTablesStayInSync:
+    """Guard against drift between the Provider enum and the routing tables. Adding a provider
+    to the enum without wiring it into every table fails loudly here, not silently at runtime."""
+
+    def _provider_values(self) -> set[str]:
+        from noidea.config import Provider
+
+        values = {member.value for member in Provider}
+        assert "anthropic" in values, "anthropic must stay the default provider"
+        return values
+
+    def test_every_non_anthropic_provider_is_openai_compat(self):
+        # An enum member not in _OPENAI_COMPAT would be accepted by config but raise
+        # "unknown provider" inside complete(); a stray compat entry would never be reachable.
+        from noidea.provider import _OPENAI_COMPAT
+
+        assert self._provider_values() - {"anthropic"} == _OPENAI_COMPAT
+
+    def test_default_base_urls_only_name_compat_providers(self):
+        from noidea.provider import _DEFAULT_BASE_URLS, _OPENAI_COMPAT
+
+        assert set(_DEFAULT_BASE_URLS).issubset(_OPENAI_COMPAT)
+
+    def test_no_key_providers_are_known_providers(self):
+        from noidea.provider import _NO_KEY_PROVIDERS
+
+        assert _NO_KEY_PROVIDERS.issubset(self._provider_values())
+
+    def test_every_key_needing_provider_has_an_env_var(self):
+        # Miss an entry here and the keyring→env-var fallback silently never fires for it.
+        from noidea.key_store import _PROVIDER_ENV_VARS
+        from noidea.provider import _NO_KEY_PROVIDERS
+
+        assert self._provider_values() - _NO_KEY_PROVIDERS == set(_PROVIDER_ENV_VARS)
+
+
 class TestCompleteOpenAiCompatErrors:
     """complete() collapses openai's exception hierarchy into one ProviderError, like anthropic's."""
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -138,6 +138,123 @@ class TestCompleteValidation:
             complete("system", "user", "model", 100, temperature=-1)
 
 
+class TestCompleteOpenAiCompat:
+    """The shared transport for the 5 non-Anthropic providers, exercised through complete()."""
+
+    def _mock_client(self, content: str | None = "feat: add thing"):
+        # Shape a fake OpenAI client whose chat.completions.create returns one text choice.
+        mock_message = MagicMock()
+        mock_message.content = content
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = mock_response
+        return mock_client
+
+    @patch("openai.OpenAI")
+    def test_ollama_uses_default_base_url_and_needs_no_key(self, mock_openai_cls):
+        mock_client = self._mock_client("feat: add login")
+        mock_openai_cls.return_value = mock_client
+
+        result = complete("system", "user", "llama3.2", 100, provider="ollama")
+
+        assert result == "feat: add login"
+        # No key configured: the SDK gets a harmless placeholder and the local default endpoint.
+        mock_openai_cls.assert_called_once_with(
+            api_key="ollama", base_url="http://localhost:11434/v1"
+        )
+        mock_client.chat.completions.create.assert_called_once_with(
+            model="llama3.2",
+            messages=[
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "user"},
+            ],
+            max_tokens=100,
+            temperature=1.0,
+        )
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_openai_resolves_key_and_uses_sdk_default_endpoint(self, mock_openai_cls, mock_key):
+        mock_openai_cls.return_value = self._mock_client("hi")
+
+        result = complete("s", "u", "gpt-4o", 50, provider="openai")
+
+        assert result == "hi"
+        # OpenAI has no per-provider default, so base_url is None (the SDK's own default).
+        mock_openai_cls.assert_called_once_with(api_key="sk-test", base_url=None)
+        mock_key.assert_called_once_with("openai")
+
+    @patch("openai.OpenAI")
+    def test_base_url_overrides_provider_default(self, mock_openai_cls):
+        mock_openai_cls.return_value = self._mock_client("ok")
+
+        complete("s", "u", "m", 10, provider="ollama", base_url="http://vllm:8000/v1")
+
+        mock_openai_cls.assert_called_once_with(api_key="ollama", base_url="http://vllm:8000/v1")
+
+    @patch("openai.OpenAI")
+    def test_raises_on_non_text_content(self, mock_openai_cls):
+        mock_openai_cls.return_value = self._mock_client(content=None)
+        with pytest.raises(TypeError, match="text completion"):
+            complete("s", "u", "m", 10, provider="ollama")
+
+
+class TestCompleteDispatch:
+    def test_unknown_provider_is_rejected(self):
+        with pytest.raises(ValueError, match="unknown provider"):
+            complete("s", "u", "m", 10, provider="not-a-provider")
+
+
+class TestCompleteOpenAiCompatErrors:
+    """complete() collapses openai's exception hierarchy into one ProviderError, like anthropic's."""
+
+    def _complete_raising(self, error):
+        with patch("openai.OpenAI") as mock_openai_cls:
+            mock_client = MagicMock()
+            mock_client.chat.completions.create.side_effect = error
+            mock_openai_cls.return_value = mock_client
+            return complete("s", "u", "m", 10, provider="ollama")
+
+    def _response(self, status_code):
+        return httpx.Response(status_code, request=httpx.Request("POST", "http://test"))
+
+    def test_auth_error_maps_to_auth_kind(self):
+        import openai
+
+        error = openai.AuthenticationError("bad key", response=self._response(401), body=None)
+        with pytest.raises(ProviderError) as exc:
+            self._complete_raising(error)
+        assert exc.value.kind is ErrorKind.AUTH
+
+    def test_rate_limit_error_maps_to_rate_limit_kind(self):
+        import openai
+
+        error = openai.RateLimitError("slow down", response=self._response(429), body=None)
+        with pytest.raises(ProviderError) as exc:
+            self._complete_raising(error)
+        assert exc.value.kind is ErrorKind.RATE_LIMIT
+
+    def test_connection_error_maps_to_connection_kind(self):
+        import openai
+
+        error = openai.APIConnectionError(request=httpx.Request("POST", "http://test"))
+        with pytest.raises(ProviderError) as exc:
+            self._complete_raising(error)
+        assert exc.value.kind is ErrorKind.CONNECTION
+
+    def test_status_error_maps_to_status_kind_with_code(self):
+        import openai
+
+        error = openai.APIStatusError("server boom", response=self._response(503), body=None)
+        with pytest.raises(ProviderError) as exc:
+            self._complete_raising(error)
+        assert exc.value.kind is ErrorKind.STATUS
+        assert exc.value.status_code == 503
+
+
 class TestCompleteNonTextBlock:
     @patch("noidea.provider.get_api_key", return_value="fake-key")
     @patch("noidea.provider.Anthropic")


### PR DESCRIPTION
Closes #27.

## What

Switching LLM provider is now a **config change, not a code change**. The transport in `provider.py` was hard-wired to Anthropic; this puts two private transports behind the existing public `complete()`:

- `_complete_anthropic(...)` — today's logic, extracted, **byte-for-byte behaviorally unchanged**.
- `_complete_openai_compat(...)` — one transport via the `openai` SDK serving **five** providers (openai/ollama/gemini/deepseek/groq), since they all speak OpenAI's chat-completions format.

`complete(..., *, provider="anthropic", base_url="")` dispatches on `provider`. The additions are keyword-only and fully backward-compatible. Both transports collapse their SDK's exception hierarchy into the existing `ProviderError(ErrorKind.*)`, so the error taxonomy stays unified in one place and callers never import a provider SDK.

**Ollama works with zero setup** — local, no API key — removing the single biggest try-it blocker (you can now try noidea without a paid key).

## Changes

- **`config.py`** — expand the `Provider` enum (openai/ollama/gemini/deepseek/groq); add `LlmConfig.provider` + `base_url`. `from_dict` coerces an unknown provider back to the default with a warning (so a hand-edited typo warns at load time rather than crashing later inside `complete()`).
- **`key_store.py`** — replace the hardcoded `ANTHROPIC_ENV_VAR` with a `_PROVIDER_ENV_VARS` table; `get()` is one loop. Ollama is absent on purpose (keyless), so it never reads an env var.
- **`provider.py`** — two transports + dispatch; per-provider default base URLs (`ollama → http://localhost:11434/v1`, etc.) overridable via config `base_url`.
- **`commands/suggest.py` + `commands/test.py`** — pass `provider`/`base_url` (two lines each, no SDK import).
- **`commands/keys.py`** — help note that Ollama needs no key.
- **`pyproject.toml`** — add `openai` (transport for 5 of 6 providers).
- **README** — document multi-provider, Ollama (no key) + OpenAI key setup, and the `base_url` override.

## How it was tested

- **140 tests pass** (`poetry run pytest -q`). All pre-existing `test_provider.py` Anthropic tests pass untouched.
- New tests: OpenAI-compat transport (mocking `openai.OpenAI`), Ollama default base-url + no-key path, base_url override, unknown-provider rejection, multi-provider env fallback in `key_store`, and unknown-provider config coercion.
- **Live end-to-end:** ran `noidea suggest` with `provider=ollama` and **no API key configured** against a local Ollama (`gemma4`), which generated `feat(calc): add add function to calculator` via the OpenAI-compat path — proving the gating acceptance criterion.
- `black` + `isort` clean; functions ≤70 lines, ≥2 assertions each, ≤100 cols (TigerStyle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple LLM providers (OpenAI, Ollama, Gemini, DeepSeek, Groq) alongside Anthropic
  * Added configurable provider selection and custom endpoint override support
  * Enabled API-key-free operation with local Ollama

* **Documentation**
  * Updated setup documentation with multi-provider configuration guidance, including provider switching and default endpoint information

* **Tests**
  * Added comprehensive test coverage for provider functionality and configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AccursedGalaxy/noidea/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->