### PR TITLE
feat(provider): support OpenAI reasoning models (o1/o3/gpt-5) on the compat path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Set `provider` in your config (see [Config](#config)) to route every request to 
 
 Set `base_url` to override the endpoint — e.g. point `openai` at a self-hosted vLLM server. Remember to also set `small_model`/`large_model` to models the provider actually serves (e.g. `"small_model": "llama3.2"` for Ollama).
 
-> **Note:** the OpenAI-compatible path sends `max_tokens`, so it targets standard chat models (e.g. `gpt-4o`, `llama3.2`). OpenAI's reasoning models (the `o1`/`o3`/`gpt-5` family) reject `max_tokens` in favour of `max_completion_tokens` and are not yet supported — pick a chat model for `small_model`/`large_model`.
+> **Reasoning models:** OpenAI's reasoning models (the `o1`/`o3`/`gpt-5` family) are supported. They take `max_completion_tokens` instead of `max_tokens` and ignore `temperature`; noidea maps the parameters automatically and, for any provider, recovers if a model unexpectedly rejects `max_tokens`. Note that reasoning models spend part of the token budget on hidden reasoning, so a low `max_tokens` may leave no room for the message — raise `llm.max_tokens` if you get an empty-completion error.
 
 ## Commands
 

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -7,6 +7,7 @@ collapse their SDK's exception hierarchy into one ProviderError here, so callers
 error type and never import a provider SDK.
 """
 
+import re
 from enum import Enum
 
 import anthropic
@@ -54,6 +55,13 @@ _DEFAULT_BASE_URLS = {
 # string, so we pass a harmless placeholder that the local backend ignores.
 _NO_KEY_PROVIDERS = {"ollama"}
 
+# OpenAI reasoning models (o-series, gpt-5) reject max_tokens and any non-default temperature;
+# they require max_completion_tokens instead. This name pattern is an OpenAI-only *hint* that lets
+# us map parameters up front and skip a wasted round-trip — it is not the correctness guarantee.
+# The structured-error retry in _create_with_param_fallback is; see issue #29. The 'chat' exclusion
+# keeps gpt-5-chat-latest (a non-reasoning endpoint) on the standard path.
+_REASONING_NAME_PATTERN = re.compile(r"^(o\d|gpt-5)")
+
 
 def get_api_key(provider: str = "anthropic") -> str:
     # key_store consults the keyring first, then the provider's *_API_KEY env var for CI/headless.
@@ -83,9 +91,13 @@ def complete(
     if not isinstance(model, str) or not model.strip():
         raise ValueError("model must be a non-empty string")
     if not isinstance(max_tokens, int) or max_tokens <= 0:
-        raise TypeError(f"max_tokens must be a positive integer, got {type(max_tokens).__name__}")
+        raise TypeError(
+            f"max_tokens must be a positive integer, got {type(max_tokens).__name__}"
+        )
     if not isinstance(temperature, (int, float)) or temperature < 0:
-        raise TypeError(f"temperature must be a non-negative number, got {temperature!r}")
+        raise TypeError(
+            f"temperature must be a non-negative number, got {temperature!r}"
+        )
     assert isinstance(provider, str) and provider, "provider must be a non-empty string"
     assert isinstance(base_url, str), "base_url must be a string"
 
@@ -104,7 +116,9 @@ def _complete_anthropic(
 ) -> str:
     """Anthropic transport: build a client, translate its errors to one ProviderError."""
     assert isinstance(model, str) and model, "model must be a non-empty string"
-    assert isinstance(max_tokens, int) and max_tokens > 0, "max_tokens must be a positive int"
+    assert isinstance(max_tokens, int) and max_tokens > 0, (
+        "max_tokens must be a positive int"
+    )
     client = Anthropic(api_key=get_api_key())
     # Specific kinds first; APIError is the catch-all base last.
     try:
@@ -122,7 +136,9 @@ def _complete_anthropic(
     except anthropic.APIConnectionError as error:
         raise ProviderError(ErrorKind.CONNECTION, str(error)) from error
     except anthropic.APIStatusError as error:
-        raise ProviderError(ErrorKind.STATUS, error.message, error.status_code) from error
+        raise ProviderError(
+            ErrorKind.STATUS, error.message, error.status_code
+        ) from error
     except anthropic.APIError as error:
         raise ProviderError(ErrorKind.STATUS, str(error)) from error
     block = message.content[0]
@@ -130,6 +146,118 @@ def _complete_anthropic(
     if not isinstance(block, TextBlock):
         raise TypeError(f"Expected TextBlock, got {type(block).__name__}")
     return block.text
+
+
+def _is_reasoning_model(model: str) -> bool:
+    """True for an OpenAI reasoning model name (o-series or gpt-5, excluding the chat endpoint).
+
+    A name *hint* only: the caller still gates this on provider == 'openai', and the real
+    correctness guarantee is the structured-error retry, not this match. See issue #29.
+    """
+    assert isinstance(model, str) and model, "model must be a non-empty string"
+    name = model.lower()
+    result = bool(_REASONING_NAME_PATTERN.match(name)) and "chat" not in name
+    assert isinstance(result, bool), "result must be a bool"
+    return result
+
+
+def _build_completion_kwargs(
+    messages: list, model: str, max_tokens: int, temperature: float, *, reasoning: bool
+) -> dict:
+    """Map a completion call to a provider's parameter dialect — the one place the split lives.
+
+    Reasoning models take max_completion_tokens and reject temperature; every other model takes
+    the classic max_tokens + temperature pair. See issue #29.
+    """
+    assert isinstance(model, str) and model, "model must be a non-empty string"
+    assert isinstance(max_tokens, int) and max_tokens > 0, (
+        "max_tokens must be a positive int"
+    )
+    kwargs: dict = {"model": model, "messages": messages}
+    if reasoning:
+        kwargs["max_completion_tokens"] = max_tokens
+    else:
+        kwargs["max_tokens"] = max_tokens
+        kwargs["temperature"] = temperature
+    assert "max_tokens" in kwargs or "max_completion_tokens" in kwargs, (
+        "must request output tokens"
+    )
+    return kwargs
+
+
+def _create_with_param_fallback(
+    client,
+    model: str,
+    messages: list,
+    max_tokens: int,
+    temperature: float,
+    *,
+    reasoning: bool,
+):
+    """Create a chat completion, collapsing openai's exception hierarchy into one ProviderError.
+
+    A reasoning model the name hint missed rejects max_tokens with a structured 400; flip to
+    reasoning params and retry once. The retry keys off the error, not the provider, so it
+    self-corrects for any compat backend, not just OpenAI. See issue #29.
+    """
+    import openai
+
+    assert isinstance(reasoning, bool), "reasoning must be a bool"
+    kwargs = _build_completion_kwargs(
+        messages, model, max_tokens, temperature, reasoning=reasoning
+    )
+    try:
+        return client.chat.completions.create(**kwargs)
+    except openai.AuthenticationError as error:
+        raise ProviderError(ErrorKind.AUTH, str(error)) from error
+    except openai.RateLimitError as error:
+        raise ProviderError(ErrorKind.RATE_LIMIT, str(error)) from error
+    except openai.APIConnectionError as error:
+        raise ProviderError(ErrorKind.CONNECTION, str(error)) from error
+    except openai.BadRequestError as error:
+        # BadRequestError subclasses APIStatusError, so this clause must precede the generic one.
+        unsupported = error.code == "unsupported_parameter" or error.param in (
+            "max_tokens",
+            "temperature",
+        )
+        if reasoning or not unsupported:
+            raise ProviderError(
+                ErrorKind.STATUS, str(error), error.status_code
+            ) from error
+        retry_kwargs = _build_completion_kwargs(
+            messages, model, max_tokens, temperature, reasoning=True
+        )
+        try:
+            return client.chat.completions.create(**retry_kwargs)
+        except openai.OpenAIError as retry_error:
+            # The reasoning-param retry also failed; collapse it rather than leak a raw SDK error.
+            raise ProviderError(ErrorKind.STATUS, str(retry_error)) from retry_error
+    except openai.APIStatusError as error:
+        raise ProviderError(ErrorKind.STATUS, str(error), error.status_code) from error
+    except openai.OpenAIError as error:
+        raise ProviderError(ErrorKind.STATUS, str(error)) from error
+
+
+def _extract_text(response) -> str:
+    """Pull the text completion, mapping an empty or budget-starved response to a ProviderError.
+
+    An empty completion is a provider failure, not a Python type error: callers only catch
+    ProviderError, so leaking anything else would crash them with an unhandled traceback.
+    """
+    assert response.choices, "response must contain at least one choice"
+    choice = response.choices[0]
+    content = choice.message.content
+    if isinstance(content, str) and content:
+        return content
+    # A length finish with no text means the token budget was spent before any visible output —
+    # typical when a reasoning model burns it all on hidden reasoning tokens — so name the fix.
+    if choice.finish_reason == "length":
+        raise ProviderError(
+            ErrorKind.STATUS,
+            "The model produced no text before exhausting its token budget. Raise llm.max_tokens"
+            " — reasoning models also spend it on hidden reasoning tokens.",
+        )
+    raise ProviderError(ErrorKind.STATUS, "The provider returned an empty completion.")
 
 
 def _complete_openai_compat(
@@ -146,35 +274,20 @@ def _complete_openai_compat(
     assert isinstance(base_url, str), "base_url must be a string"
     # openai is a core dependency, imported lazily so the Anthropic default path never pays
     # its import cost. A missing openai is an install fault, not a runtime error to handle.
-    import openai
     from openai import OpenAI
 
     # base_url precedence: explicit config > per-provider default > the SDK's own default (None).
     resolved_base_url = base_url or _DEFAULT_BASE_URLS.get(provider, "")
     api_key = "ollama" if provider in _NO_KEY_PROVIDERS else get_api_key(provider)
     client = OpenAI(api_key=api_key, base_url=resolved_base_url or None)
-    try:
-        response = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
-    except openai.AuthenticationError as error:
-        raise ProviderError(ErrorKind.AUTH, str(error)) from error
-    except openai.RateLimitError as error:
-        raise ProviderError(ErrorKind.RATE_LIMIT, str(error)) from error
-    except openai.APIConnectionError as error:
-        raise ProviderError(ErrorKind.CONNECTION, str(error)) from error
-    except openai.APIStatusError as error:
-        raise ProviderError(ErrorKind.STATUS, str(error), error.status_code) from error
-    except openai.OpenAIError as error:
-        raise ProviderError(ErrorKind.STATUS, str(error)) from error
-    content = response.choices[0].message.content
-    # A compat backend can return None or a non-string when no text was produced.
-    if not isinstance(content, str) or not content:
-        raise TypeError(f"Expected a text completion, got {type(content).__name__}")
-    return content
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    # The name hint is an OpenAI-only optimization; the retry inside the fallback is what makes a
+    # missed reasoning model still work. See issue #29.
+    reasoning = provider == "openai" and _is_reasoning_model(model)
+    response = _create_with_param_fallback(
+        client, model, messages, max_tokens, temperature, reasoning=reasoning
+    )
+    return _extract_text(response)

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -203,6 +203,7 @@ def _create_with_param_fallback(
     import openai
 
     assert isinstance(reasoning, bool), "reasoning must be a bool"
+    assert isinstance(messages, list) and messages, "messages must be a non-empty list"
     kwargs = _build_completion_kwargs(
         messages, model, max_tokens, temperature, reasoning=reasoning
     )
@@ -216,6 +217,10 @@ def _create_with_param_fallback(
         raise ProviderError(ErrorKind.CONNECTION, str(error)) from error
     except openai.BadRequestError as error:
         # BadRequestError subclasses APIStatusError, so this clause must precede the generic one.
+        # We also accept the bare param name, not just code == "unsupported_parameter", so the
+        # retry survives the SDK changing or dropping the code; the cost is that an unrelated 400
+        # naming these params (e.g. an out-of-range max_tokens) triggers one wasted retry that
+        # then collapses to ProviderError anyway.
         unsupported = error.code == "unsupported_parameter" or error.param in (
             "max_tokens",
             "temperature",
@@ -247,6 +252,9 @@ def _extract_text(response) -> str:
     assert response.choices, "response must contain at least one choice"
     choice = response.choices[0]
     content = choice.message.content
+    assert content is None or isinstance(content, str), (
+        "content must be a string or None"
+    )
     if isinstance(content, str) and content:
         return content
     # A length finish with no text means the token budget was spent before any visible output —

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -83,7 +83,9 @@ class TestCompleteErrors:
         assert exc.value.kind is ErrorKind.RATE_LIMIT
 
     def test_connection_error_maps_to_connection_kind(self):
-        error = anthropic.APIConnectionError(request=httpx.Request("POST", "http://test"))
+        error = anthropic.APIConnectionError(
+            request=httpx.Request("POST", "http://test")
+        )
         with pytest.raises(ProviderError) as exc:
             self._complete_raising(error)
         assert exc.value.kind is ErrorKind.CONNECTION
@@ -99,7 +101,9 @@ class TestCompleteErrors:
 
     def test_unknown_api_error_falls_through_to_status_kind(self):
         # Any anthropic.APIError not matched above must still not leak past the seam.
-        error = anthropic.APIError("boom", request=httpx.Request("POST", "http://test"), body=None)
+        error = anthropic.APIError(
+            "boom", request=httpx.Request("POST", "http://test"), body=None
+        )
         with pytest.raises(ProviderError) as exc:
             self._complete_raising(error)
         assert exc.value.kind is ErrorKind.STATUS
@@ -177,7 +181,9 @@ class TestCompleteOpenAiCompat:
 
     @patch("noidea.provider.get_api_key", return_value="sk-test")
     @patch("openai.OpenAI")
-    def test_openai_resolves_key_and_uses_sdk_default_endpoint(self, mock_openai_cls, mock_key):
+    def test_openai_resolves_key_and_uses_sdk_default_endpoint(
+        self, mock_openai_cls, mock_key
+    ):
         mock_openai_cls.return_value = self._mock_client("hi")
 
         result = complete("s", "u", "gpt-4o", 50, provider="openai")
@@ -193,13 +199,202 @@ class TestCompleteOpenAiCompat:
 
         complete("s", "u", "m", 10, provider="ollama", base_url="http://vllm:8000/v1")
 
-        mock_openai_cls.assert_called_once_with(api_key="ollama", base_url="http://vllm:8000/v1")
+        mock_openai_cls.assert_called_once_with(
+            api_key="ollama", base_url="http://vllm:8000/v1"
+        )
 
     @patch("openai.OpenAI")
-    def test_raises_on_non_text_content(self, mock_openai_cls):
+    def test_empty_content_raises_provider_error(self, mock_openai_cls):
+        # An empty completion is a provider failure, not a Python type error: it must collapse to
+        # ProviderError so callers (which only catch ProviderError) handle it gracefully instead
+        # of crashing with an unhandled traceback.
         mock_openai_cls.return_value = self._mock_client(content=None)
-        with pytest.raises(TypeError, match="text completion"):
+        with pytest.raises(ProviderError) as exc:
             complete("s", "u", "m", 10, provider="ollama")
+        assert exc.value.kind is ErrorKind.STATUS
+
+
+class TestReasoningModels:
+    """OpenAI reasoning models (o-series, gpt-5) reject max_tokens and a non-default temperature;
+    the compat transport must send max_completion_tokens and omit temperature for them."""
+
+    def _response(self, content: str | None = "feat: x", finish_reason: str = "stop"):
+        # A single chat-completions response carrying finish_reason, so the starvation path
+        # (length-truncated, empty content) is expressible.
+        mock_message = MagicMock()
+        mock_message.content = content
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_choice.finish_reason = finish_reason
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        return mock_response
+
+    def _mock_client(
+        self, content: str | None = "feat: x", finish_reason: str = "stop"
+    ):
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = self._response(
+            content, finish_reason
+        )
+        return mock_client
+
+    def _unsupported_param_error(self, param: str = "max_tokens"):
+        # The structured 400 OpenAI returns when a reasoning model is sent a chat-only parameter.
+        import openai
+
+        return openai.BadRequestError(
+            f"Unsupported parameter: '{param}' is not supported with this model.",
+            response=httpx.Response(400, request=httpx.Request("POST", "http://test")),
+            body={"code": "unsupported_parameter", "param": param},
+        )
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_reasoning_model_maps_to_max_completion_tokens_and_drops_temperature(
+        self, mock_openai_cls, mock_key
+    ):
+        mock_client = self._mock_client("feat: add thing")
+        mock_openai_cls.return_value = mock_client
+
+        # temperature=0.7 is deliberately non-default: the assertion is that we drop it, not
+        # that it happens to equal the only value reasoning models accept.
+        result = complete("s", "u", "o3-mini", 100, temperature=0.7, provider="openai")
+
+        assert result == "feat: add thing"
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 100
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    @pytest.mark.parametrize("model", ["gpt-4o", "gpt-5-chat-latest"])
+    def test_chat_model_keeps_max_tokens_and_temperature(
+        self, mock_openai_cls, mock_key, model
+    ):
+        # gpt-5-chat-latest is a non-reasoning endpoint: the 'chat' exclusion must keep it here,
+        # not on the reasoning path. gpt-4o is the plain regression guard.
+        mock_client = self._mock_client("feat: add thing")
+        mock_openai_cls.return_value = mock_client
+
+        complete("s", "u", model, 100, temperature=0.7, provider="openai")
+
+        kwargs = mock_client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 100
+        assert kwargs["temperature"] == 0.7
+        assert "max_completion_tokens" not in kwargs
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_unsupported_parameter_error_retries_once_with_reasoning_params(
+        self, mock_openai_cls, mock_key
+    ):
+        # A reasoning model the name hint misses: the first (chat-param) call is rejected with the
+        # structured 400, so the transport flips to reasoning params and retries once.
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            self._unsupported_param_error("max_tokens"),
+            self._response("feat: add thing"),
+        ]
+        mock_openai_cls.return_value = mock_client
+
+        result = complete(
+            "s", "u", "gpt-6-thinking", 100, temperature=0.7, provider="openai"
+        )
+
+        assert result == "feat: add thing"
+        assert mock_client.chat.completions.create.call_count == 2
+        first = mock_client.chat.completions.create.call_args_list[0].kwargs
+        second = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "max_tokens" in first  # first attempt used the chat-param path
+        assert second["max_completion_tokens"] == 100
+        assert "max_tokens" not in second
+        assert "temperature" not in second
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_retry_is_provider_agnostic(self, mock_openai_cls, mock_key):
+        # The retry keys off the structured error, not the provider: a non-OpenAI compat backend
+        # (here deepseek) that rejects max_tokens is recovered the same way, for free.
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            self._unsupported_param_error("max_tokens"),
+            self._response("fix: thing"),
+        ]
+        mock_openai_cls.return_value = mock_client
+
+        result = complete("s", "u", "deepseek-reasoner", 100, provider="deepseek")
+
+        assert result == "fix: thing"
+        assert mock_client.chat.completions.create.call_count == 2
+        assert (
+            "max_completion_tokens"
+            in mock_client.chat.completions.create.call_args_list[1].kwargs
+        )
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_retry_failure_surfaces_as_provider_error(self, mock_openai_cls, mock_key):
+        # When the reasoning-param retry also fails, the SDK error must not leak: it collapses
+        # into a ProviderError like every other transport failure.
+        import openai
+
+        second = openai.APIStatusError(
+            "server boom",
+            response=httpx.Response(503, request=httpx.Request("POST", "http://test")),
+            body=None,
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            self._unsupported_param_error("max_tokens"),
+            second,
+        ]
+        mock_openai_cls.return_value = mock_client
+
+        with pytest.raises(ProviderError) as exc:
+            complete("s", "u", "gpt-6-thinking", 100, provider="openai")
+
+        assert exc.value.kind is ErrorKind.STATUS
+        assert mock_client.chat.completions.create.call_count == 2
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_non_param_bad_request_does_not_retry(self, mock_openai_cls, mock_key):
+        # A 400 that is not an unsupported-parameter error (e.g. context length) is a genuine
+        # failure: collapse to STATUS on the first call, do not retry.
+        import openai
+
+        error = openai.BadRequestError(
+            "context length exceeded",
+            response=httpx.Response(400, request=httpx.Request("POST", "http://test")),
+            body={"code": "context_length_exceeded"},
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = error
+        mock_openai_cls.return_value = mock_client
+
+        with pytest.raises(ProviderError) as exc:
+            complete("s", "u", "gpt-4o", 100, provider="openai")
+
+        assert exc.value.kind is ErrorKind.STATUS
+        assert mock_client.chat.completions.create.call_count == 1
+
+    @patch("noidea.provider.get_api_key", return_value="sk-test")
+    @patch("openai.OpenAI")
+    def test_budget_starvation_raises_actionable_provider_error(
+        self, mock_openai_cls, mock_key
+    ):
+        # A reasoning model can spend its whole budget on hidden reasoning tokens and return empty
+        # content with a length finish. Surface an actionable ProviderError naming the fix, not a
+        # cryptic TypeError.
+        mock_openai_cls.return_value = self._mock_client(
+            content=None, finish_reason="length"
+        )
+        with pytest.raises(ProviderError) as exc:
+            complete("s", "u", "o3-mini", 100, provider="openai")
+        assert exc.value.kind is ErrorKind.STATUS
+        assert "max_tokens" in str(exc.value)
 
 
 class TestCompleteDispatch:
@@ -260,7 +455,9 @@ class TestCompleteOpenAiCompatErrors:
     def test_auth_error_maps_to_auth_kind(self):
         import openai
 
-        error = openai.AuthenticationError("bad key", response=self._response(401), body=None)
+        error = openai.AuthenticationError(
+            "bad key", response=self._response(401), body=None
+        )
         with pytest.raises(ProviderError) as exc:
             self._complete_raising(error)
         assert exc.value.kind is ErrorKind.AUTH
@@ -268,7 +465,9 @@ class TestCompleteOpenAiCompatErrors:
     def test_rate_limit_error_maps_to_rate_limit_kind(self):
         import openai
 
-        error = openai.RateLimitError("slow down", response=self._response(429), body=None)
+        error = openai.RateLimitError(
+            "slow down", response=self._response(429), body=None
+        )
         with pytest.raises(ProviderError) as exc:
             self._complete_raising(error)
         assert exc.value.kind is ErrorKind.RATE_LIMIT
@@ -284,7 +483,9 @@ class TestCompleteOpenAiCompatErrors:
     def test_status_error_maps_to_status_kind_with_code(self):
         import openai
 
-        error = openai.APIStatusError("server boom", response=self._response(503), body=None)
+        error = openai.APIStatusError(
+            "server boom", response=self._response(503), body=None
+        )
         with pytest.raises(ProviderError) as exc:
             self._complete_raising(error)
         assert exc.value.kind is ErrorKind.STATUS


### PR DESCRIPTION
Closes #29.

## Problem

The shared OpenAI-compat transport sent `max_tokens` and `temperature` unconditionally. OpenAI's **reasoning** models (`o`-series, `gpt-5`) reject both — they require `max_completion_tokens` and accept only the default `temperature`. A user who configured one on `provider: openai` got a raw SDK `BadRequestError`, not graceful handling.

## Design

Decision-tree was grilled before any code; the load-bearing call is **the predicate is an optimization, the retry is the correctness guarantee**.

- **`_build_completion_kwargs`** — the *one* place the parameter split lives. Reasoning → `max_completion_tokens`, omit `temperature`; everything else → unchanged `max_tokens` + `temperature`.
- **`_is_reasoning_model`** — an OpenAI-only name *hint* (`^o\d` / `gpt-5`, excluding `gpt-5-chat-latest`). It only avoids a wasted round-trip; it is deliberately narrow and never the source of truth.
- **`_create_with_param_fallback`** — one-shot retry on the structured 400 (`code == "unsupported_parameter"`). Keys off the *error*, not the provider, so it self-corrects for **any** compat backend (Groq/Gemini/DeepSeek) and survives OpenAI's naming churn. `BadRequestError` intercept is ordered before the generic `APIStatusError` handler (it's a subclass). A failing retry collapses to `ProviderError` — no raw SDK leak.
- **`_extract_text`** — empty completion now raises `ProviderError` instead of a `TypeError` that escaped callers (which only catch `ProviderError`). A length-truncated empty response — a reasoning model spending its whole budget on hidden reasoning — gets an actionable message pointing at `llm.max_tokens`.

`_complete_openai_compat` is decomposed into these five helpers, each under the 70-line limit.

## Acceptance criteria

- ✅ Reasoning model produces a completion, or a clear `ProviderError` (never a raw SDK crash).
- ✅ `temperature` dropped for reasoning models (omitted, not coerced).
- ✅ Standard chat models unchanged — regression-guarded (`gpt-4o`, `gpt-5-chat-latest`).
- ✅ Tests cover the parameter-mapping decision, retry, provider-agnostic retry, retry exhaustion, non-param 400, and budget starvation.

## Tests

8 new behavior tests through the public `complete()` seam (so they survive the decomposition); the one existing empty-content test updated `TypeError` → `ProviderError`. Full suite: **152 passing**, ruff clean on changed files, all functions ≤70 lines.

## Deferred (no evidence yet, per TigerStyle)

`reasoning_effort`/budget config knob, `o1-mini` system→developer remapping, new `ErrorKind`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)