### PR TITLE
feat(provider): OpenRouter support (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-02
+
+### Added
+- **OpenRouter provider support**: set `"provider": "openrouter"` to route requests through [OpenRouter](https://openrouter.ai), the OpenAI-compatible aggregator that fronts many upstream models behind one endpoint. Store a key with `noidea keys add openrouter` or the `OPENROUTER_API_KEY` env var. Because OpenRouter is an aggregator, models are addressed by their namespaced name (e.g. `anthropic/claude-3.5-sonnet`). Wired entirely through the existing OpenAI-compatible transport, so it inherits the shared error taxonomy and the reasoning-parameter fallback for free.
+
 ## [1.1.0] - 2026-05-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ By default noidea uses Anthropic (Claude). The key is looked up in three places,
 | **Environment variable** | `export ANTHROPIC_API_KEY=sk-ant-...` |
 | **`.env` file** | `ANTHROPIC_API_KEY=sk-ant-...` in a `.env` file |
 
-Other providers follow the same pattern with their own env var (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`) or `noidea keys add <provider>`.
+Other providers follow the same pattern with their own env var (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `DEEPSEEK_API_KEY`, `GROQ_API_KEY`, `OPENROUTER_API_KEY`) or `noidea keys add <provider>`.
 
 **Ollama needs no key.** It runs locally, so once `provider` is set to `ollama` (below) you can generate commit messages with nothing else configured.
 
@@ -84,6 +84,7 @@ Set `provider` in your config (see [Config](#config)) to route every request to 
 | `gemini` | yes | Google's OpenAI-compatible endpoint |
 | `deepseek` | yes | `https://api.deepseek.com` |
 | `groq` | yes | `https://api.groq.com/openai/v1` |
+| `openrouter` | yes | `https://openrouter.ai/api/v1` |
 
 Set `base_url` to override the endpoint — e.g. point `openai` at a self-hosted vLLM server. Remember to also set `small_model`/`large_model` to models the provider actually serves (e.g. `"small_model": "llama3.2"` for Ollama).
 

--- a/noidea/config.py
+++ b/noidea/config.py
@@ -36,6 +36,7 @@ class Provider(str, Enum):
     GEMINI = "gemini"
     DEEPSEEK = "deepseek"
     GROQ = "groq"
+    OPENROUTER = "openrouter"
 
 
 @dataclass(frozen=True)
@@ -50,17 +51,25 @@ class LlmConfig:
     max_tokens: int = 1024
     small_model: str = "claude-haiku-4-5"
     large_model: str = "claude-sonnet-4-6"
-    context_limit: float = 600000.0  # Character threshold for model selection, not a token limit.
+    context_limit: float = (
+        600000.0  # Character threshold for model selection, not a token limit.
+    )
     system_prompt: str = _DEFAULT_SYSTEM_PROMPT
     temperature: float = 1.0
     learn_commit_style: bool = True  # Match the repo's observed commit conventions.
-    provider: str = "anthropic"  # Which backend complete() dispatches to; see provider.py.
-    base_url: str = ""  # Overrides the per-provider default endpoint (e.g. a custom vLLM host).
+    provider: str = (
+        "anthropic"  # Which backend complete() dispatches to; see provider.py.
+    )
+    base_url: str = (
+        ""  # Overrides the per-provider default endpoint (e.g. a custom vLLM host).
+    )
 
     def __post_init__(self):
         # The pair to from_dict's pre-construction type check: assert the invariants
         # after construction, so a bad dataclasses.replace is caught as a programmer error.
-        assert isinstance(self.max_tokens, int) and not isinstance(self.max_tokens, bool)
+        assert isinstance(self.max_tokens, int) and not isinstance(
+            self.max_tokens, bool
+        )
         assert isinstance(self.small_model, str)
         assert isinstance(self.large_model, str)
         assert isinstance(self.context_limit, (int, float))
@@ -110,7 +119,9 @@ class LlmConfig:
 
     def select_model(self, context_length_chars: int) -> str:
         """Pick the large or small model based on a character-count heuristic."""
-        assert isinstance(context_length_chars, int), "context_length_chars must be an int"
+        assert isinstance(context_length_chars, int), (
+            "context_length_chars must be an int"
+        )
         assert context_length_chars >= 0, "context_length_chars must be non-negative"
         if context_length_chars >= self.context_limit:
             return self.large_model
@@ -143,7 +154,11 @@ def deep_merge(base, override):
     while stack:
         target, source = stack.pop()
         for key, value in source.items():
-            if key in target and isinstance(value, dict) and isinstance(target[key], dict):
+            if (
+                key in target
+                and isinstance(value, dict)
+                and isinstance(target[key], dict)
+            ):
                 target[key] = target[key].copy()
                 stack.append((target[key], value))
             else:

--- a/noidea/key_store.py
+++ b/noidea/key_store.py
@@ -33,6 +33,7 @@ _PROVIDER_ENV_VARS = {
     "gemini": "GEMINI_API_KEY",
     "deepseek": "DEEPSEEK_API_KEY",
     "groq": "GROQ_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
 }
 
 
@@ -44,7 +45,9 @@ class KeyStatus(Enum):
     """The reconciliation state of a provider across the two stores."""
 
     PRESENT = "present"  # Registered and the keyring holds its secret.
-    MISSING_SECRET = "missing_secret"  # Registered but the keyring has no secret (drift).
+    MISSING_SECRET = (
+        "missing_secret"  # Registered but the keyring has no secret (drift).
+    )
     UNREGISTERED = "unregistered"  # Not in the registry at all.
 
 
@@ -53,7 +56,9 @@ class KeyStore:
 
     def __init__(self, keyring_backend, registry_path: str):
         assert keyring_backend is not None, "keyring_backend must be provided"
-        assert isinstance(registry_path, str) and registry_path, "registry_path must be non-empty"
+        assert isinstance(registry_path, str) and registry_path, (
+            "registry_path must be non-empty"
+        )
         self._keyring = keyring_backend
         self._registry_path = registry_path
 
@@ -64,13 +69,17 @@ class KeyStore:
         If the registry write fails after the keyring write, the keyring secret is rolled
         back so no orphan secret survives the failure.
         """
-        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        assert isinstance(provider, str) and provider, (
+            "provider must be a non-empty string"
+        )
         assert isinstance(secret, str) and secret, "secret must be a non-empty string"
         names = self._read_registry()
         try:
             self._keyring.set_password(SERVICE_NAME, provider, secret)
         except keyring.errors.KeyringError as error:
-            raise KeyStoreError(f"could not write secret to keyring: {error}") from error
+            raise KeyStoreError(
+                f"could not write secret to keyring: {error}"
+            ) from error
         if provider in names:
             return False
         names.append(provider)
@@ -83,7 +92,9 @@ class KeyStore:
 
     def remove(self, provider: str) -> bool:
         """Remove the name from the registry and the secret from the keyring; True if it existed."""
-        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        assert isinstance(provider, str) and provider, (
+            "provider must be a non-empty string"
+        )
         names = self._read_registry()
         if provider not in names:
             return False
@@ -98,7 +109,9 @@ class KeyStore:
             # Roll back the registry so the two stores never disagree after a failure.
             names.append(provider)
             self._write_registry(names)
-            raise KeyStoreError(f"could not delete secret from keyring: {error}") from error
+            raise KeyStoreError(
+                f"could not delete secret from keyring: {error}"
+            ) from error
         return True
 
     def list(self) -> list[str]:
@@ -109,19 +122,25 @@ class KeyStore:
 
     def get(self, provider: str) -> str | None:
         """Return the keyring secret, falling back to the provider's env var if it has one."""
-        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        assert isinstance(provider, str) and provider, (
+            "provider must be a non-empty string"
+        )
         secret = self._read_secret(provider)
         if not secret:
             # No keyless provider (e.g. ollama) is in the table, so it never reads an env var.
             env_var = _PROVIDER_ENV_VARS.get(provider)
             if env_var:
                 secret = os.environ.get(env_var)
-        assert secret is None or isinstance(secret, str), "secret must be a string or None"
+        assert secret is None or isinstance(secret, str), (
+            "secret must be a string or None"
+        )
         return secret
 
     def status_of(self, provider: str) -> KeyStatus:
         """Reconcile the two stores for one provider into a single status."""
-        assert isinstance(provider, str) and provider, "provider must be a non-empty string"
+        assert isinstance(provider, str) and provider, (
+            "provider must be a non-empty string"
+        )
         registered = provider in self._read_registry()
         # Read the keyring directly, bypassing the env fallback, so real drift stays visible.
         has_secret = bool(self._read_secret(provider))
@@ -134,7 +153,9 @@ class KeyStore:
         try:
             return self._keyring.get_password(SERVICE_NAME, provider)
         except keyring.errors.KeyringError as error:
-            raise KeyStoreError(f"could not read secret from keyring: {error}") from error
+            raise KeyStoreError(
+                f"could not read secret from keyring: {error}"
+            ) from error
 
     def _delete_quietly(self, provider: str) -> None:
         """Best-effort keyring delete used to roll back a half-written add; never raises."""

--- a/noidea/provider.py
+++ b/noidea/provider.py
@@ -39,7 +39,7 @@ class ProviderError(Exception):
 
 
 # Providers that speak OpenAI's chat-completions format, served by the one shared transport.
-_OPENAI_COMPAT = {"openai", "ollama", "gemini", "deepseek", "groq"}
+_OPENAI_COMPAT = {"openai", "ollama", "gemini", "deepseek", "groq", "openrouter"}
 
 # The default endpoint per OpenAI-compat provider; config base_url overrides any of these.
 # OpenAI itself has no entry, so it falls through to the SDK's own default base URL.
@@ -49,6 +49,9 @@ _DEFAULT_BASE_URLS = {
     # DeepSeek's base intentionally has no /v1 suffix: its API also serves the OpenAI path here.
     "deepseek": "https://api.deepseek.com",
     "groq": "https://api.groq.com/openai/v1",
+    # OpenRouter is a pure aggregator: one OpenAI-compat endpoint fronting many upstream models,
+    # selected by a namespaced model name (e.g. "anthropic/claude-3.5-sonnet").
+    "openrouter": "https://openrouter.ai/api/v1",
 }
 
 # Providers that need no API key (local, keyless). The OpenAI SDK still wants a non-empty key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "noidea"
-version = "1.1.0"
+version = "1.2.0"
 description = "AI commit messages that pre-fill your git editor — Claude-powered, conventional-commits aware, learns your repo's style."
 authors = [
     {name = "AccursedGalaxy",email = "robinbohrer7@gmail.com"}

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -193,6 +193,25 @@ class TestCompleteOpenAiCompat:
         mock_openai_cls.assert_called_once_with(api_key="sk-test", base_url=None)
         mock_key.assert_called_once_with("openai")
 
+    @patch("noidea.provider.get_api_key", return_value="sk-or-test")
+    @patch("openai.OpenAI")
+    def test_openrouter_resolves_key_and_uses_aggregator_endpoint(
+        self, mock_openai_cls, mock_key
+    ):
+        # OpenRouter is keyed like any compat provider but fronts upstream models behind one
+        # endpoint, so the model name is namespaced and the base URL is its aggregator default.
+        mock_openai_cls.return_value = self._mock_client("feat: add thing")
+
+        result = complete(
+            "s", "u", "anthropic/claude-3.5-sonnet", 50, provider="openrouter"
+        )
+
+        assert result == "feat: add thing"
+        mock_openai_cls.assert_called_once_with(
+            api_key="sk-or-test", base_url="https://openrouter.ai/api/v1"
+        )
+        mock_key.assert_called_once_with("openrouter")
+
     @patch("openai.OpenAI")
     def test_base_url_overrides_provider_default(self, mock_openai_cls):
         mock_openai_cls.return_value = self._mock_client("ok")


### PR DESCRIPTION
## What

Adds **OpenRouter** as a first-class provider and ships it as **v1.2.0**.

OpenRouter speaks OpenAI's chat-completions format, so it slots into the existing shared OpenAI-compat transport — no new client, no new error handling. It's an aggregator, so models are addressed by their namespaced name (e.g. `anthropic/claude-3.5-sonnet`).

## Changes

- `config.py` — add `OPENROUTER` to the `Provider` enum (gives `noidea keys add openrouter` for free)
- `provider.py` — add `openrouter` to `_OPENAI_COMPAT` and its default endpoint (`https://openrouter.ai/api/v1`) to `_DEFAULT_BASE_URLS`
- `key_store.py` — add `OPENROUTER_API_KEY` to the keyring→env fallback table
- `tests/test_provider.py` — test that it resolves its key and hits the aggregator endpoint; the existing `TestProviderTablesStayInSync` guards enforce every routing table stays in step
- `README.md` — provider table + env-var list
- `release: v1.2.0` — `pyproject.toml` bump + CHANGELOG entry

## Usage

```bash
noidea keys add openrouter          # or export OPENROUTER_API_KEY=...
```
```json
{ "llm": { "provider": "openrouter", "small_model": "anthropic/claude-3.5-haiku", "large_model": "anthropic/claude-3.5-sonnet" } }
```

## Notes

- Inherits the shared error taxonomy and the reasoning-parameter fallback for free.
- Did **not** wire OpenRouter's optional `HTTP-Referer`/`X-Title` attribution headers — not required, and would mean special-casing the otherwise provider-agnostic transport.
- The version bump also resyncs the manifest: the `v1.1.1` tag was cut without bumping `pyproject.toml` (still at `1.1.0`), so `1.2.0` realigns them.

## Test plan

- `poetry run pytest` — 153 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter provider support. Configure `"provider": "openrouter"` to route requests through OpenRouter using `OPENROUTER_API_KEY` (or `noidea keys add openrouter`). Access models via namespaced identifiers (e.g., `anthropic/claude-3.5-sonnet`).

* **Documentation**
  * Updated README with OpenRouter provider configuration and API key setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->